### PR TITLE
feat: defineRouteKit + mapDomainErrors + $use union overload

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -51,6 +51,18 @@ export interface ProcedureBuilder<
   /** Add a wrap middleware — does not change context type */
   $use(wrap: WrapDef<any>): ProcedureBuilder<TType, TBaseCtx, TCtx, TInput, TErrors>
 
+  /**
+   * Add a middleware of unknown variant (`GuardDef | WrapDef`).
+   *
+   * @remarks
+   * Used by factory-pattern builders that accept middleware through a
+   * dependency boundary where the concrete variant isn't known at the
+   * call site. Context is not enriched — if you need guard-added fields
+   * in `.$resolve()`, pass the guard with its concrete type or use
+   * `defineRouteKit` to bind the ctx shape up front.
+   */
+  $use(mw: MiddlewareDef): ProcedureBuilder<TType, TBaseCtx, TCtx, TInput, TErrors>
+
   /** Set input schema */
   $input<TSchema extends AnySchema>(
     schema: TSchema,
@@ -111,6 +123,16 @@ export interface ProcedureBuilderWithOutput<
 
   /** Add a wrap middleware — does not change context type */
   $use(wrap: WrapDef<any>): ProcedureBuilderWithOutput<TType, TBaseCtx, TCtx, TInput, TOutputResolved, TErrors>
+
+  /**
+   * Add a middleware of unknown variant (`GuardDef | WrapDef`).
+   *
+   * @remarks
+   * Used by factory-pattern builders that accept middleware through a
+   * dependency boundary where the concrete variant isn't known at the
+   * call site.
+   */
+  $use(mw: MiddlewareDef): ProcedureBuilderWithOutput<TType, TBaseCtx, TCtx, TInput, TOutputResolved, TErrors>
 
   /** Set typed errors */
   $errors<TNewErrors extends ErrorDef>(

--- a/src/error-mapper.ts
+++ b/src/error-mapper.ts
@@ -1,0 +1,71 @@
+/**
+ * mapDomainErrors — convert service-layer errors into SilgiError.
+ *
+ * @remarks
+ * Library service layers typically throw a domain error (no HTTP
+ * knowledge), and route handlers convert them to {@link SilgiError}
+ * before returning. Writing the same try/catch wrapper in every
+ * resolver is boilerplate; `mapDomainErrors` replaces it with a single
+ * mapper function that runs on every thrown error.
+ *
+ * @example
+ * ```ts
+ * class DomainError extends Error {
+ *   constructor(public code: string, public status: number, message: string) { super(message) }
+ * }
+ *
+ * const toSilgi = mapDomainErrors((e) => {
+ *   if (e instanceof DomainError) {
+ *     return new SilgiError(e.code, { status: e.status, message: e.message, defined: true })
+ *   }
+ * })
+ *
+ * k.$resolve(toSilgi(async ({ input }) => service.doThing(input)))
+ * ```
+ */
+
+import { SilgiError, isSilgiError } from './core/error.ts'
+
+/**
+ * Map a caught error into a {@link SilgiError}, or return `undefined` to
+ * rethrow the original error untouched. `SilgiError` instances always
+ * pass through unchanged — the mapper is not invoked for them.
+ */
+export type DomainErrorMapper = (error: unknown) => SilgiError | undefined
+
+/**
+ * Create a resolver wrapper that runs `mapper` on every thrown error.
+ *
+ * @param mapper - Called with the caught error; return a `SilgiError` to
+ *   replace it, or `undefined` to rethrow the original.
+ * @returns A function that wraps a resolver and applies the mapping.
+ *
+ * @example
+ * ```ts
+ * const handleErrors = mapDomainErrors((e) => {
+ *   if (e instanceof MyDomainError) {
+ *     return new SilgiError(e.code, { status: e.status, message: e.message, defined: true })
+ *   }
+ * })
+ *
+ * k.$resolve(handleErrors(async ({ input, ctx }) => {
+ *   return await service.run(input, ctx)
+ * }))
+ * ```
+ */
+export function mapDomainErrors(mapper: DomainErrorMapper) {
+  return function wrap<TArgs extends unknown[], TReturn>(
+    fn: (...args: TArgs) => TReturn | Promise<TReturn>,
+  ): (...args: TArgs) => Promise<TReturn> {
+    return async (...args: TArgs): Promise<TReturn> => {
+      try {
+        return await fn(...args)
+      } catch (e) {
+        if (isSilgiError(e)) throw e
+        const mapped = mapper(e)
+        if (mapped) throw mapped
+        throw e
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ export type {
 // ── Error ───────────────────────────────────────────
 export { SilgiError, isSilgiError, isDefinedError, toSilgiError } from './core/error.ts'
 export type { SilgiErrorCode, SilgiErrorOptions, SilgiErrorJSON } from './core/error.ts'
+export { mapDomainErrors } from './error-mapper.ts'
+export type { DomainErrorMapper } from './error-mapper.ts'
+
+// ── Route Kit (factory for isolated packages) ───────
+export { defineRouteKit } from './route-kit.ts'
+export type { RouteKit, RouteKitDeps, GuardMap, GuardDeps } from './route-kit.ts'
 
 // ── Schema ──────────────────────────────────────────
 export { type, validateSchema, ValidationError } from './core/schema.ts'

--- a/src/route-kit.ts
+++ b/src/route-kit.ts
@@ -1,0 +1,109 @@
+/**
+ * defineRouteKit — factory helper for isolated-package route builders.
+ *
+ * @remarks
+ * In monorepos where domain packages (commerce, PIM, MES…) do not own a
+ * Silgi instance, routes are written as factories that accept the
+ * instance and the guards via dependency injection at the server wiring
+ * point. Without a kit, every factory has to fall back to `any` for
+ * both the guard refs and the resolver `ctx`, because the concrete
+ * guard types aren't known inside the package.
+ *
+ * `defineRouteKit<Ctx>()` fixes the ctx shape at the kit level and
+ * lets the package declare the guard return types it depends on. The
+ * resolver then receives a ctx correctly enriched with every declared
+ * guard's return — no `as any`, no manual intersection.
+ *
+ * @example
+ * ```ts
+ * // package/src/kit.ts
+ * import { defineRouteKit } from 'silgi'
+ * export const kit = defineRouteKit<MyCtx>()
+ *
+ * // package/src/routes/posts.api.ts
+ * export const createPost = kit.route<{
+ *   auth: { user: { id: number } }
+ *   org: { orgId: string }
+ * }>()(({ s, auth, org }) =>
+ *   s.$route({ method: 'POST', path: '/posts' })
+ *     .$use(auth)
+ *     .$use(org)
+ *     .$input(z.object({ title: z.string() }))
+ *     .$resolve(({ input, ctx }) => {
+ *       ctx.user.id    // ✓ typed
+ *       ctx.orgId      // ✓ typed
+ *     }),
+ * )
+ *
+ * // server/src/index.ts
+ * import { createPost } from 'package/routes/posts.api.ts'
+ * const k = silgi({ context: (req) => buildMyCtx(req) })
+ * const authGuard = k.guard(...)
+ * const orgGuard  = k.guard(...)
+ *
+ * const posts = {
+ *   create: createPost({ s: k, auth: authGuard, org: orgGuard }),
+ * }
+ * ```
+ */
+
+import type { SilgiInstance } from './silgi.ts'
+import type { ErrorDef, GuardDef } from './types.ts'
+
+/**
+ * Shape of a `guards` map passed to a kit route. Each entry declares the
+ * context additions that specific guard contributes.
+ */
+export type GuardMap = Record<string, Record<string, unknown> | void>
+
+/** Convert a `GuardMap` into the deps object shape passed to kit builders. */
+export type GuardDeps<TGuards extends GuardMap> = {
+  [K in keyof TGuards]: GuardDef<any, TGuards[K], ErrorDef>
+}
+
+/** Deps injected into a kit route builder — the instance plus the typed guards. */
+export type RouteKitDeps<TCtx extends Record<string, unknown>, TGuards extends GuardMap> = {
+  s: SilgiInstance<TCtx>
+} & GuardDeps<TGuards>
+
+/**
+ * Return value of `defineRouteKit<Ctx>()`.
+ *
+ * @remarks
+ * Use {@link RouteKit.route} to declare a single route that depends on a
+ * named set of guards. The kit carries no runtime state — it only
+ * binds the ctx shape for inference.
+ */
+export interface RouteKit<TCtx extends Record<string, unknown>> {
+  /**
+   * Declare a route factory.
+   *
+   * @typeParam TGuards - Map of guard name → context additions. Empty by
+   *   default; pass an explicit shape when the route depends on guards.
+   *
+   * @example
+   * ```ts
+   * kit.route<{ auth: { user: User } }>()(({ s, auth }) =>
+   *   s.$use(auth).$resolve(({ ctx }) => ctx.user)
+   * )
+   * ```
+   */
+  route: <TGuards extends GuardMap = {}>() => <TReturn>(
+    builder: (deps: RouteKitDeps<TCtx, TGuards>) => TReturn,
+  ) => (deps: RouteKitDeps<TCtx, TGuards>) => TReturn
+}
+
+/**
+ * Create a context-bound route kit for isolated packages.
+ *
+ * @typeParam TCtx - Base context shape the server will provide. Flows
+ *   into every route's resolver through the injected `s` instance.
+ */
+export function defineRouteKit<TCtx extends Record<string, unknown>>(): RouteKit<TCtx> {
+  return {
+    route:
+      <_TGuards extends GuardMap = {}>() =>
+      <TReturn>(builder: (deps: RouteKitDeps<TCtx, _TGuards>) => TReturn) =>
+        builder,
+  }
+}

--- a/test/core/error-brand.test.ts
+++ b/test/core/error-brand.test.ts
@@ -59,7 +59,7 @@ describe('SilgiError — brand and type guards', () => {
 
   it('toJSON() produces exactly the five expected keys', () => {
     const e = new SilgiError('NOT_FOUND', { data: { foo: 'bar' } })
-    const keys = Object.keys(e.toJSON()).sort()
+    const keys = Object.keys(e.toJSON()).toSorted()
     expect(keys).toEqual(['code', 'data', 'defined', 'message', 'status'])
   })
 })

--- a/test/core/error-mapper.test.ts
+++ b/test/core/error-mapper.test.ts
@@ -1,0 +1,91 @@
+/**
+ * mapDomainErrors — service-layer error translation for resolvers.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { SilgiError, isSilgiError } from '#src/core/error.ts'
+import { mapDomainErrors } from '#src/error-mapper.ts'
+import { silgi } from '#src/silgi.ts'
+
+class DomainError extends Error {
+  constructor(
+    public code: string,
+    public status: number,
+    message: string,
+    public info?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = 'DomainError'
+  }
+}
+
+describe('mapDomainErrors', () => {
+  const handle = mapDomainErrors((e) => {
+    if (e instanceof DomainError) {
+      return new SilgiError(e.code, {
+        status: e.status,
+        message: e.message,
+        data: e.info,
+        defined: true,
+      })
+    }
+  })
+
+  it('passes through return value when no error', async () => {
+    const fn = handle(async (x: number) => x * 2)
+    expect(await fn(3)).toBe(6)
+  })
+
+  it('maps DomainError to SilgiError with status + defined flag', async () => {
+    const fn = handle(async () => {
+      throw new DomainError('NOT_FOUND', 404, 'missing')
+    })
+    await expect(fn()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      status: 404,
+      message: 'missing',
+      defined: true,
+    })
+  })
+
+  it('rethrows SilgiError unchanged (mapper not called for them)', async () => {
+    let called = false
+    const wrap = mapDomainErrors((_e) => {
+      called = true
+      return new SilgiError('BAD_REQUEST')
+    })
+    const silgiErr = new SilgiError('CONFLICT', { status: 409, defined: true })
+    const fn = wrap(async () => {
+      throw silgiErr
+    })
+    await expect(fn()).rejects.toBe(silgiErr)
+    expect(called).toBe(false)
+  })
+
+  it('rethrows original error when mapper returns undefined', async () => {
+    const weird = new Error('boom')
+    const fn = handle(async () => {
+      throw weird
+    })
+    await expect(fn()).rejects.toBe(weird)
+  })
+
+  it('integrates with silgi resolvers', async () => {
+    const k = silgi({ context: () => ({}) })
+    const proc = k.$errors({ NOT_FOUND: 404 }).$resolve(
+      handle(async () => {
+        throw new DomainError('NOT_FOUND', 404, 'user missing')
+      }),
+    )
+    const caller = k.createCaller(k.router({ get: proc }))
+    try {
+      await caller.get()
+      throw new Error('expected rejection')
+    } catch (e) {
+      expect(isSilgiError(e)).toBe(true)
+      expect((e as SilgiError).code).toBe('NOT_FOUND')
+      expect((e as SilgiError).status).toBe(404)
+    }
+  })
+})

--- a/test/core/route-kit.test.ts
+++ b/test/core/route-kit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * defineRouteKit — factory-pattern route builder for isolated packages.
+ */
+
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { z } from 'zod'
+
+import { defineRouteKit } from '#src/route-kit.ts'
+import { silgi } from '#src/silgi.ts'
+
+import type { ProcedureDef } from '#src/types.ts'
+
+interface PackageCtx extends Record<string, unknown> {
+  db: { users: { id: number; name: string }[] }
+}
+
+describe('defineRouteKit', () => {
+  it('binds ctx at kit level, flows through to resolver', async () => {
+    const kit = defineRouteKit<PackageCtx>()
+
+    const listUsers = kit.route()(({ s }) =>
+      s.$resolve(({ ctx }) => {
+        expectTypeOf(ctx.db.users).toEqualTypeOf<{ id: number; name: string }[]>()
+        return ctx.db.users
+      }),
+    )
+
+    const k = silgi({ context: () => ({ db: { users: [{ id: 1, name: 'Alice' }] } }) })
+    const proc = listUsers({ s: k })
+
+    expectTypeOf(proc).toMatchTypeOf<ProcedureDef<'query', undefined, { id: number; name: string }[], {}>>()
+
+    const caller = k.createCaller(k.router({ listUsers: proc }))
+    expect(await caller.listUsers()).toEqual([{ id: 1, name: 'Alice' }])
+  })
+
+  it('typed guards — ctx additions flow into $resolve', async () => {
+    const kit = defineRouteKit<PackageCtx>()
+
+    const createPost = kit.route<{
+      auth: { userId: number }
+      org: { orgId: string }
+    }>()(({ s, auth, org }) =>
+      s
+        .$use(auth)
+        .$use(org)
+        .$input(z.object({ title: z.string() }))
+        .$resolve(({ input, ctx }) => {
+          expectTypeOf(ctx.userId).toEqualTypeOf<number>()
+          expectTypeOf(ctx.orgId).toEqualTypeOf<string>()
+          expectTypeOf(ctx.db.users).toEqualTypeOf<{ id: number; name: string }[]>()
+          return { title: input.title, by: ctx.userId, org: ctx.orgId }
+        }),
+    )
+
+    const k = silgi({ context: () => ({ db: { users: [] } }) })
+    const authGuard = k.guard(() => ({ userId: 42 }))
+    const orgGuard = k.guard(() => ({ orgId: 'acme' }))
+
+    const proc = createPost({ s: k, auth: authGuard, org: orgGuard })
+    const caller = k.createCaller(k.router({ createPost: proc }))
+    expect(await caller.createPost({ title: 'hello' })).toEqual({
+      title: 'hello',
+      by: 42,
+      org: 'acme',
+    })
+  })
+
+  it('kit routes are identity — builder fn is returned unchanged', () => {
+    const kit = defineRouteKit<PackageCtx>()
+    const builder = ({ s }: { s: any }) => s.$resolve(() => 1)
+    const defined = kit.route()(builder)
+    expect(defined).toBe(builder)
+  })
+})

--- a/test/core/use-union.test.ts
+++ b/test/core/use-union.test.ts
@@ -1,0 +1,32 @@
+/**
+ * $use() — union overload accepts `GuardDef | WrapDef` at boundary points.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { silgi } from '#src/silgi.ts'
+
+import type { MiddlewareDef } from '#src/types.ts'
+
+describe('$use union overload', () => {
+  it('accepts a GuardDef | WrapDef value without discriminating the variant', async () => {
+    const k = silgi({ context: () => ({ db: 'x' as const }) })
+
+    const guard = k.guard(() => ({ userId: 1 }))
+    const wrap = k.wrap(async (_ctx, next) => next())
+
+    // Caller sees them through a union boundary (e.g. injected through DI):
+    const mws: MiddlewareDef[] = [guard, wrap]
+
+    const b = k.$resolve(() => 'root')
+    expect(b).toBeDefined()
+
+    // Each passes through $use without TS error (compile-time guarantee).
+    let chain = k.$route({}) as any
+    for (const mw of mws) chain = chain.$use(mw)
+    const proc = chain.$resolve(() => 'ok')
+
+    const caller = k.createCaller(k.router({ proc }))
+    expect(await caller.proc()).toBe('ok')
+  })
+})


### PR DESCRIPTION
Closes #9.

## Summary
- **`$use()` third overload** accepts `GuardDef | WrapDef` so factories passing middleware through a DI boundary don't have to pick a variant or cast.
- **`defineRouteKit<Ctx>()`** — context-bound factory for isolated packages. Declares guard-return shapes so the resolver `ctx` keeps injected-guard fields across the package boundary.
- **`mapDomainErrors(mapper)`** — resolver wrapper that translates service-layer errors to `SilgiError`. Passes `SilgiError` through unchanged; rethrows the original when the mapper returns `undefined`.

## Usage

```ts
// package/kit.ts
export const kit = defineRouteKit<MyCtx>()

// package/posts.api.ts
export const createPost = kit.route<{
  auth: { user: { id: number } }
  org: { orgId: string }
}>()(({ s, auth, org }) =>
  s.$route({ method: 'POST', path: '/posts' })
    .$use(auth)
    .$use(org)
    .$input(z.object({ title: z.string() }))
    .$resolve(({ input, ctx }) => {
      ctx.user.id   // ✓ typed
      ctx.orgId     // ✓ typed
      return { ok: true }
    }),
)

// server wiring
createPost({ s: k, auth: authGuard, org: orgGuard })
```

```ts
const handle = mapDomainErrors((e) => {
  if (e instanceof MyDomainError) {
    return new SilgiError(e.code, { status: e.status, message: e.message, defined: true })
  }
})

k.$resolve(handle(async ({ input }) => service.run(input)))
```

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 864 passed, 19 skipped (9 new tests across route-kit, error-mapper, union overload)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)