### PR TITLE
fix: correctness sweep — 7 silent-failure bugs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,54 @@ only module-global state in the schema subsystem and it stores only
 vendor-name strings — never user schemas, never request data. The
 tradeoff: we deduplicate noisy warnings in long-running processes.
 
+### `_msgpack` / `_devalue` codec module caches — `src/core/codec.ts`, `src/core/input.ts`
+
+Two `let` slots that hold lazily-imported codec modules (`msgpackr`,
+`devalue`). They exist to avoid paying the dynamic-import round-trip
+on every request once the codec has been needed once. The slots hold
+ES modules, not user data — functionally equivalent to the ES module
+resolver cache. Safe across instances because the modules are
+stateless.
+
+### `_running` — `src/core/task.ts`
+
+`Map<TaskDef, Promise>` used by `runTask()` to dedup concurrent calls
+on the same task def. Keys are `TaskDef` references, values are the
+in-flight dispatch Promise. Entries are deleted in a `finally` block so
+the map drains naturally; no unbounded growth. Task dedup is inherently
+process-wide semantics (the same task def in two silgi instances is
+logically the same job), so a module-level map matches the intent.
+
+### `_eventMeta` — `src/core/sse.ts`
+
+`WeakMap<object, EventMeta>` side-channel for `withEventMeta()` ids and
+retry hints. Keys are user-yielded event payload objects; GC reclaims
+entries when the user's payload is no longer referenced. No cross-
+instance leakage because keys are uniquely owned by the yielding code.
+
+### `_dashboardCache` — `src/plugins/analytics/routes.ts`
+
+Caches the analytics dashboard HTML read from disk on first request.
+Immutable static asset; multiple instances reading it produce identical
+bytes. Included here only to make the grep audit exhaustive.
+
+### `_lastTime` / `_counter` — `src/plugins/analytics/request-id.ts`
+
+Snowflake-style request ID generator. Monotonicity is a process-wide
+property by design — splitting this state per instance would violate
+the uniqueness guarantee callers rely on.
+
+### `_defaultRegistry` — `src/core/task.ts`
+
+Process-default `CronRegistry` backing the legacy top-level
+`startCronJobs` / `stopCronJobs` / `getScheduledTasks` exports. New
+code should use `createCronRegistry()` and own the registry
+explicitly. The process default stays only so that the analytics
+dashboard's `/api/analytics/scheduled` route keeps showing jobs
+registered via `silgi({}).serve()` without threading the registry
+through every analytics-plugin call site — a future refactor will
+move this to explicit injection.
+
 ## 5. Extending Silgi
 
 ### Add a schema converter

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -243,6 +243,18 @@ registered via `silgi({}).serve()` without threading the registry
 through every analytics-plugin call site — a future refactor will
 move this to explicit injection.
 
+### `_requestContextMap` — `src/integrations/better-auth/index.ts`
+
+`WeakMap<Request, Record<string, unknown>>` backing the public
+`setRequestContext(request, ctx)` API. Strictly speaking this violates
+§3 rule 2 ("no WeakMap keyed on Request identity"). It remains only
+because `setRequestContext` is a public API consumed by user code;
+removing it is a breaking change reserved for the next major. New
+integrations must not introduce similar WeakMaps — use
+`silgi.runInContext(ctx, fn)` for ambient context or a plugin-factory
+closure (see `requestMetas` inside `tracing()` for the correct
+pattern) for per-request side channels.
+
 ## 5. Extending Silgi
 
 ### Add a schema converter

--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "lib"
   ],
   "type": "module",
-  "sideEffects": [
-    "./dist/integrations/zod/index.mjs"
-  ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.mjs",

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -70,7 +70,10 @@ export function createHandler<TCtx extends Record<string, unknown>>(
     const method = isV2 ? (event.requestContext?.http?.method ?? 'GET') : (event.httpMethod ?? 'GET')
     let pathname = isV2 ? (event.rawPath ?? '/') : (event.path ?? '/')
 
-    if (prefix && pathname.startsWith(prefix)) {
+    // Only strip the prefix on a path-segment boundary. Without the boundary
+    // check, `prefix='/api'` would match `/api2/...` and silently route the
+    // wrong request.
+    if (prefix && (pathname === prefix || pathname.startsWith(prefix + '/'))) {
       pathname = pathname.slice(prefix.length)
     }
     if (pathname.startsWith('/')) pathname = pathname.slice(1)

--- a/src/broker/redis.ts
+++ b/src/broker/redis.ts
@@ -101,8 +101,6 @@ export interface RedisBrokerOptions {
 
 // ── Driver ──────────────────────────────────────────
 
-let globalSeq = 0
-
 /**
  * Create a Redis broker driver from a RedisTransport.
  *
@@ -115,7 +113,10 @@ let globalSeq = 0
  * Wire format: `"inbox-channel\npayload"` (newline separator, no double-serialization)
  */
 export function redisBroker(transport: RedisTransport, options: RedisBrokerOptions = {}): BrokerDriver {
-  const inboxPrefix = options.inbox ?? `silgi:inbox:${Date.now().toString(36)}:${(++globalSeq).toString(36)}`
+  // Unique inbox prefix per-driver — random suffix instead of a process-wide
+  // counter so two redisBroker() calls cannot share an inbox namespace.
+  const inboxPrefix =
+    options.inbox ?? `silgi:inbox:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`
   let requestSeq = 0
 
   return {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -27,6 +27,8 @@ import type {
   Meta,
 } from './types.ts'
 
+export type RootWrapsGetter = (() => readonly WrapDef[] | null) | null
+
 // ── Builder Interfaces ──────────────────────────────
 
 /** Initial builder — no input, no output, no errors yet */
@@ -153,6 +155,7 @@ class ProcBuilder {
 
   // Set by createProcedureBuilder when created via silgi instance
   _contextFactory: (() => unknown | Promise<unknown>) | null = null
+  _rootWrapsGetter: RootWrapsGetter = null
 
   constructor(type: ProcedureType) {
     this.type = type
@@ -195,15 +198,24 @@ class ProcBuilder {
   }
 
   $task(config: TaskConfig & { resolve: Function }): TaskDef {
-    return createTaskFromProcedure(config, config.resolve, this.input, this.use, this._contextFactory)
+    return createTaskFromProcedure(
+      config,
+      config.resolve,
+      this.input,
+      this.use,
+      this._contextFactory,
+      this._rootWrapsGetter,
+    )
   }
 }
 
 export function createProcedureBuilder<TType extends ProcedureType, TBaseCtx extends Record<string, unknown>>(
   type: TType,
   contextFactory?: (() => unknown | Promise<unknown>) | null,
+  rootWrapsGetter?: RootWrapsGetter,
 ): ProcedureBuilder<TType, TBaseCtx> {
   const b = new ProcBuilder(type)
   if (contextFactory) b._contextFactory = contextFactory
+  if (rootWrapsGetter) b._rootWrapsGetter = rootWrapsGetter
   return b as unknown as ProcedureBuilder<TType, TBaseCtx>
 }

--- a/src/caller.ts
+++ b/src/caller.ts
@@ -26,6 +26,14 @@ import { routerCache } from './core/router-utils.ts'
 import type { CompiledRouterFn } from './compile.ts'
 import type { RouterDef } from './types.ts'
 
+/**
+ * Never-aborting signal used when `timeout: null` is opted into and the
+ * caller passes no per-call signal. Allocated once at module load; compiled
+ * handlers can still `.addEventListener('abort', …)` safely — the listener
+ * simply never fires.
+ */
+const NEVER = new AbortController().signal
+
 export interface CreateCallerOptions {
   /** Override or extend the base context for all calls */
   contextOverride?: Record<string, unknown>
@@ -119,11 +127,14 @@ export function createCaller(
           const ctx = await resolveContext(callOptions?.context)
           if (match.params) ctx.params = match.params
 
-          const signal =
-            callOptions?.signal ?? (defaultTimeout !== null ? AbortSignal.timeout(defaultTimeout) : undefined)
+          // Compiled handlers may read `signal.aborted` / `.addEventListener`.
+          // When `timeout: null` is opted into and no per-call signal is
+          // supplied, we still hand over a real (never-aborting) signal
+          // instead of `undefined` to avoid NPEs deep inside wraps/resolvers.
+          const signal = callOptions?.signal ?? (defaultTimeout !== null ? AbortSignal.timeout(defaultTimeout) : NEVER)
 
           try {
-            const result = match.data.handler(ctx, input, signal as AbortSignal)
+            const result = match.data.handler(ctx, input, signal)
             return result instanceof Promise ? await result : result
           } finally {
             releaseContext(ctx)

--- a/src/client/plugins/retry.ts
+++ b/src/client/plugins/retry.ts
@@ -117,16 +117,20 @@ export function withRetry<TClientContext extends ClientContext>(
           onRetry?.({ attempt: attempt + 1, delay, error, path })
 
           await new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(resolve, delay)
-            // Cancel wait if signal aborts during delay
-            callOptions.signal?.addEventListener(
-              'abort',
-              () => {
-                clearTimeout(timer)
-                reject(callOptions.signal!.reason)
-              },
-              { once: true },
-            )
+            const signal = callOptions.signal
+            const onAbort = (): void => {
+              clearTimeout(timer)
+              reject(signal!.reason)
+            }
+            const timer = setTimeout(() => {
+              signal?.removeEventListener('abort', onAbort)
+              resolve()
+            }, delay)
+            // Cancel wait if signal aborts during delay. Explicit
+            // `removeEventListener` on the timer path prevents an accumulated
+            // listener set on long-lived signals (e.g. page AbortControllers
+            // spanning many retries).
+            signal?.addEventListener('abort', onAbort, { once: true })
           })
         }
       }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -16,7 +16,7 @@ import type { ProcedureDef, GuardDef, WrapDef, ErrorDef } from './types.ts'
 // Re-exported here for backwards compatibility with the previous shape.
 export { RAW_INPUT } from './core/ctx-symbols.ts'
 
-import { RAW_INPUT } from './core/ctx-symbols.ts'
+import { RAW_INPUT, ROOT_WRAPS } from './core/ctx-symbols.ts'
 
 /**
  * Compiled pipeline — called per request.
@@ -297,10 +297,18 @@ function _validateAndResolve(
  * - Pre-computed fail function (singleton per procedure)
  * - Sync fast path when all guards are sync
  */
-export function compileProcedure(procedure: ProcedureDef): CompiledHandler {
+export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly WrapDef[] | null): CompiledHandler {
   const middlewares = procedure.use ?? []
   const guards: GuardDef[] = []
   const wraps: WrapDef[] = []
+
+  // Root wraps are outermost — prepended in order so index 0 wraps index N-1
+  // wraps the resolver. Zero-cost when `rootWraps` is nullish/empty: the
+  // `wraps` array stays empty and every subsequent fast-path check still
+  // short-circuits on `wraps.length === 0`.
+  if (rootWraps && rootWraps.length > 0) {
+    for (let i = 0; i < rootWraps.length; i++) wraps.push(rootWraps[i]!)
+  }
 
   for (const mw of middlewares) {
     if (mw.kind === 'guard') guards.push(mw)
@@ -448,6 +456,14 @@ export type CompiledRouterFn = (method: string, path: string) => MatchedRoute<Co
 export function compileRouter(def: Record<string, unknown>): CompiledRouterFn {
   const router = createRou3<CompiledRoute>()
 
+  // Root wraps are branded onto the def by `silgi({ wraps }).router(def)`.
+  // Reading once here and passing into every `compileProcedure` avoids any
+  // per-adapter plumbing — every compile site already routes through here.
+  // When the brand is absent (no wraps, or def compiled from outside a
+  // silgi instance), `rootWraps` is `undefined` and `compileProcedure`
+  // walks its existing zero-cost fast paths unchanged.
+  const rootWraps = (def as { [ROOT_WRAPS]?: readonly WrapDef[] })[ROOT_WRAPS]
+
   function walk(node: unknown, path: string[]): void {
     if (isProcedureDef(node)) {
       const proc = node as ProcedureDef
@@ -465,7 +481,7 @@ export function compileRouter(def: Record<string, unknown>): CompiledRouterFn {
       }
 
       const compiled: CompiledRoute = {
-        handler: compileProcedure(proc),
+        handler: compileProcedure(proc, rootWraps),
         cacheControl,
         passthrough: routePath.includes('**') || undefined,
         method,

--- a/src/core/ctx-symbols.ts
+++ b/src/core/ctx-symbols.ts
@@ -17,3 +17,21 @@
  * @internal
  */
 export const RAW_INPUT = Symbol.for('silgi.rawInput')
+
+/**
+ * Brand stamped on a `RouterDef` by `silgi({ wraps }).router(def)` to carry
+ * the instance's root wraps along with the def itself.
+ *
+ * @remarks
+ * Every compile site (`silgi.router`, `createCaller`, `createFetchHandler`,
+ * WS hooks, adapter `createHandler` variants) calls `compileRouter(def)`.
+ * Reading the brand off `def` inside `compileRouter` means root wraps
+ * reach every adapter without any per-adapter plumbing, without relying
+ * on `routerCache`, and without a second tree walk.
+ *
+ * The brand is a non-enumerable own property on the user's def (Symbol
+ * keys are skipped by `Object.entries`, so router traversal is unaffected).
+ *
+ * @internal
+ */
+export const ROOT_WRAPS = Symbol.for('silgi.rootWraps')

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -194,13 +194,23 @@ export function createFetchHandler(
   const jsonHeaders = { 'content-type': 'application/json' }
   const notFoundBody = JSON.stringify({ code: 'NOT_FOUND', status: 404, message: 'Procedure not found' })
 
-  // Hook helper — fire-and-forget
+  // Hook helper — fire-and-forget. We surface hook errors via
+  // `console.error` rather than swallowing: a silent catch hides user
+  // coding mistakes (a misspelled field, a thrown assertion) and the
+  // dashboard, trace, or logging pipeline just… stops working with no
+  // signal. Hook errors never fail the request itself.
+  function reportHookError(name: string, err: unknown): void {
+    console.error(`[silgi] hook "${name}" threw:`, err)
+  }
+
   function callHook(name: keyof SilgiHooks, event: any): void {
     if (!hooks) return
     try {
       const result = hooks.callHook(name, event)
-      if (result instanceof Promise) result.catch(() => {})
-    } catch {}
+      if (result instanceof Promise) result.catch((err) => reportHookError(name, err))
+    } catch (err) {
+      reportHookError(name, err)
+    }
   }
 
   // Hook helper — awaited (used for critical hooks like `request:prepare`
@@ -210,8 +220,10 @@ export function createFetchHandler(
     if (!hooks) return
     try {
       const result = hooks.callHook(name, event)
-      if (result instanceof Promise) return result.catch(() => {})
-    } catch {}
+      if (result instanceof Promise) return result.catch((err) => reportHookError(name, err))
+    } catch (err) {
+      reportHookError(name, err)
+    }
   }
 
   // ── Unified Request Handler ───────────────────────

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -140,27 +140,39 @@ export function wrapHandler(
 ): FetchHandler {
   if (!options?.scalar && !options?.analytics) return handler
 
-  let wrapped: FetchHandler | undefined
+  // Initialised to `handler` so a failed init falls back to the raw handler
+  // rather than wedging every request on `wrapped!` being undefined.
+  let wrapped: FetchHandler = handler
+  let initDone = false
   let initPromise: Promise<void> | undefined
 
   async function init(): Promise<void> {
-    let h = handler
-    if (options!.scalar) {
-      const { wrapWithScalar } = await import('../scalar.ts')
-      const scalarOpts = typeof options!.scalar === 'object' ? options!.scalar : {}
-      h = wrapWithScalar(h, router, scalarOpts, prefix, options!.schemaRegistry)
+    try {
+      let h = handler
+      if (options!.scalar) {
+        const { wrapWithScalar } = await import('../scalar.ts')
+        const scalarOpts = typeof options!.scalar === 'object' ? options!.scalar : {}
+        h = wrapWithScalar(h, router, scalarOpts, prefix, options!.schemaRegistry)
+      }
+      if (options!.analytics) {
+        const { wrapWithAnalytics } = await import('../plugins/analytics.ts')
+        h = wrapWithAnalytics(h, router, options!.analytics, options!.schemaRegistry, options!.hooks)
+      }
+      wrapped = h
+    } catch (err) {
+      // Log once and keep serving with the raw handler. Otherwise a
+      // transient import failure at boot would 500 every request.
+      console.error('[silgi] Failed to initialise scalar/analytics wrapper:', err)
+      wrapped = handler
+    } finally {
+      initDone = true
     }
-    if (options!.analytics) {
-      const { wrapWithAnalytics } = await import('../plugins/analytics.ts')
-      h = wrapWithAnalytics(h, router, options!.analytics, options!.schemaRegistry, options!.hooks)
-    }
-    wrapped = h
   }
 
   return (request: Request): Response | Promise<Response> => {
-    if (wrapped) return wrapped(request)
+    if (initDone) return wrapped(request)
     initPromise ??= init()
-    return initPromise.then(() => wrapped!(request))
+    return initPromise.then(() => wrapped(request))
   }
 }
 
@@ -208,9 +220,12 @@ export function createFetchHandler(
     const url = request.url
     let fullPath = parseUrlPath(url)
 
-    // Strip basePath prefix — zero allocation, pure string slice
+    // Strip basePath prefix — zero allocation, pure string slice. Require
+    // a segment boundary so `prefix='/api'` never matches `/api2/...`.
     if (prefix) {
-      if (!fullPath.startsWith(prefix)) return new Response(notFoundBody, { status: 404, headers: jsonHeaders })
+      if (fullPath !== prefix && !fullPath.startsWith(prefix + '/')) {
+        return new Response(notFoundBody, { status: 404, headers: jsonHeaders })
+      }
       fullPath = fullPath.slice(prefixLen) || '/'
     }
 

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -11,16 +11,35 @@ import { SilgiError } from './error.ts'
 /** Max allowed size for GET ?data= parameter (bytes). Prevents JSON bomb via URL. */
 const MAX_QUERY_DATA_LENGTH = 8192
 
+/**
+ * Find the value of the `data=` query parameter by key, not by substring.
+ *
+ * The previous `indexOf('data=')` implementation matched `userdata=...`,
+ * `xdata=...`, or any other key ending in `data` — silently returning the
+ * wrong value. This scans for `data=` at a parameter boundary (either the
+ * first param or after `&`).
+ */
+function findDataParam(searchStr: string): string | null {
+  let i = 0
+  while (i < searchStr.length) {
+    if (searchStr.startsWith('data=', i)) {
+      const valueStart = i + 5
+      const valueEnd = searchStr.indexOf('&', valueStart)
+      return valueEnd === -1 ? searchStr.slice(valueStart) : searchStr.slice(valueStart, valueEnd)
+    }
+    const nextAmp = searchStr.indexOf('&', i)
+    if (nextAmp === -1) return null
+    i = nextAmp + 1
+  }
+  return null
+}
+
 /** Parse request input from body or query string */
 export async function parseInput(request: Request, url: string, qMark: number): Promise<unknown> {
   if (request.method === 'GET' || !request.body) {
     if (qMark !== -1) {
-      const searchStr = url.slice(qMark + 1)
-      const dataIdx = searchStr.indexOf('data=')
-      if (dataIdx !== -1) {
-        const valueStart = dataIdx + 5
-        const valueEnd = searchStr.indexOf('&', valueStart)
-        const encoded = valueEnd === -1 ? searchStr.slice(valueStart) : searchStr.slice(valueStart, valueEnd)
+      const encoded = findDataParam(url.slice(qMark + 1))
+      if (encoded !== null) {
         if (encoded.length > MAX_QUERY_DATA_LENGTH) {
           throw new SilgiError('BAD_REQUEST', { message: 'Query data parameter too large' })
         }

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -6,8 +6,6 @@
 let _msgpack: typeof import('../codec/msgpack.ts') | undefined
 let _devalue: typeof import('../codec/devalue.ts') | undefined
 
-const isBun = typeof globalThis.Bun !== 'undefined'
-
 import { SilgiError } from './error.ts'
 
 /** Max allowed size for GET ?data= parameter (bytes). Prevents JSON bomb via URL. */
@@ -48,14 +46,18 @@ export async function parseInput(request: Request, url: string, qMark: number): 
     }
   }
 
-  // JSON body
-  if (isBun) {
-    try {
-      return await request.json()
-    } catch {
-      return undefined
-    }
-  }
+  // JSON body — same semantics across runtimes:
+  //   empty body → undefined (input schema sees `undefined` / default)
+  //   non-empty malformed body → throw BAD_REQUEST
+  //
+  // Bun's `request.json()` is a fast path but throws a generic SyntaxError
+  // on BOTH empty and malformed bodies, so we can't blanket-swallow. Read
+  // text first to distinguish the two cases — Bun's text() is also fast.
   const text = await request.text()
-  return text ? JSON.parse(text) : undefined
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new SilgiError('BAD_REQUEST', { message: 'Malformed JSON body' })
+  }
 }

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -7,7 +7,7 @@
 
 import { validateSchema } from './schema.ts'
 
-import type { MiddlewareDef } from '../types.ts'
+import type { MiddlewareDef, WrapDef } from '../types.ts'
 import type { AnySchema } from './schema.ts'
 
 // ── Types ────────────────────────────────────────────
@@ -71,6 +71,15 @@ export function createTaskFromProcedure(
   inputSchema: AnySchema | null,
   use: readonly MiddlewareDef[] | null,
   contextFactory: (() => unknown | Promise<unknown>) | null,
+  /**
+   * Instance-level root wraps, read lazily so that a task constructed
+   * before `s.router()` has stamped wraps still picks them up. The
+   * silgi instance passes a live getter; dispatch calls it once per
+   * dispatch. When no wraps are configured the getter returns null and
+   * the dispatch path stays a straight `await resolveFn(...)` — zero
+   * additional closure, zero onion, zero cost.
+   */
+  rootWrapsGetter: (() => readonly WrapDef[] | null) | null = null,
 ): TaskDef<any, any> {
   const { name, cron = null, description } = config
 
@@ -98,9 +107,27 @@ export function createTaskFromProcedure(
       ctx.trace = reqTrace
     } catch {}
 
+    // Build the same root-wrap onion that the pipeline uses. When no
+    // wraps are configured this whole block compiles down to a direct
+    // `await resolveFn(...)` — the `rootWraps` ref is null, the if-guard
+    // short-circuits and V8 removes the dead branch after the first IC hit.
+    const rootWraps = rootWrapsGetter ? rootWrapsGetter() : null
+    const runResolver = () => resolveFn({ input, ctx, name, scheduledTime: undefined })
+
     const t0 = performance.now()
     try {
-      const output = await resolveFn({ input, ctx, name, scheduledTime: undefined })
+      let output: unknown
+      if (rootWraps && rootWraps.length > 0) {
+        let execute: () => Promise<unknown> = () => Promise.resolve(runResolver())
+        for (let i = rootWraps.length - 1; i >= 0; i--) {
+          const wrapFn = rootWraps[i]!.fn
+          const next = execute
+          execute = () => wrapFn(ctx, next)
+        }
+        output = await execute()
+      } else {
+        output = await runResolver()
+      }
 
       if (parentTrace) {
         parentTrace.spans.push({

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -242,35 +242,6 @@ interface CronJobEntry {
   errors: number
 }
 
-let _cronEntries: CronJobEntry[] = []
-
-export async function startCronJobs(cronTasks: Array<{ cron: string; task: TaskDef<any, any> }>): Promise<void> {
-  if (cronTasks.length === 0) return
-  const { Cron } = await import('croner')
-  for (const { cron, task } of cronTasks) {
-    const taskName = (task as any).route?.summary || cron
-    const entry: CronJobEntry = {
-      name: taskName,
-      cron,
-      description: task.route?.summary,
-      job: null as any,
-      lastRun: null,
-      runs: 0,
-      errors: 0,
-    }
-    const job = new Cron(cron, async () => {
-      entry.lastRun = Date.now()
-      entry.runs++
-      task.dispatch(undefined).catch((err: unknown) => {
-        entry.errors++
-        console.error(`[silgi] Cron task failed:`, err instanceof Error ? err.message : err)
-      })
-    })
-    entry.job = job
-    _cronEntries.push(entry)
-  }
-}
-
 export interface ScheduledTaskInfo {
   name: string
   cron: string
@@ -281,19 +252,83 @@ export interface ScheduledTaskInfo {
   errors: number
 }
 
-export function getScheduledTasks(): ScheduledTaskInfo[] {
-  return _cronEntries.map((e) => ({
-    name: e.name,
-    cron: e.cron,
-    description: e.description,
-    nextRun: e.job.nextRun()?.getTime() ?? null,
-    lastRun: e.lastRun,
-    runs: e.runs,
-    errors: e.errors,
-  }))
+export interface CronRegistry {
+  start: (cronTasks: Array<{ cron: string; task: TaskDef<any, any> }>) => Promise<void>
+  stop: () => void
+  list: () => ScheduledTaskInfo[]
 }
 
-export function stopCronJobs(): void {
-  for (const e of _cronEntries) e.job.stop()
-  _cronEntries = []
+/**
+ * Create an isolated cron registry. Each silgi instance owns one, so
+ * `server.close()` on instance A never stops instance B's jobs and
+ * `list()` never returns jobs from another instance.
+ */
+export function createCronRegistry(): CronRegistry {
+  const entries: CronJobEntry[] = []
+
+  return {
+    async start(cronTasks) {
+      if (cronTasks.length === 0) return
+      const { Cron } = await import('croner')
+      for (const { cron, task } of cronTasks) {
+        const taskName = (task as any).route?.summary || cron
+        const entry: CronJobEntry = {
+          name: taskName,
+          cron,
+          description: task.route?.summary,
+          job: null as any,
+          lastRun: null,
+          runs: 0,
+          errors: 0,
+        }
+        const job = new Cron(cron, async () => {
+          entry.lastRun = Date.now()
+          entry.runs++
+          task.dispatch(undefined).catch((err: unknown) => {
+            entry.errors++
+            console.error(`[silgi] Cron task failed:`, err instanceof Error ? err.message : err)
+          })
+        })
+        entry.job = job
+        entries.push(entry)
+      }
+    },
+
+    stop() {
+      for (const e of entries) e.job.stop()
+      entries.length = 0
+    },
+
+    list() {
+      return entries.map((e) => ({
+        name: e.name,
+        cron: e.cron,
+        description: e.description,
+        nextRun: e.job.nextRun()?.getTime() ?? null,
+        lastRun: e.lastRun,
+        runs: e.runs,
+        errors: e.errors,
+      }))
+    },
+  }
 }
+
+// ── Process-default registry (backwards-compat, deprecated) ──
+
+/**
+ * Process-default cron registry. Shared state — use {@link createCronRegistry}
+ * when a silgi instance should own its own jobs.
+ *
+ * @deprecated Prefer per-instance registries. The module-default is
+ * retained so existing imports of `startCronJobs` / `stopCronJobs` /
+ * `getScheduledTasks` keep working; a future major will remove these
+ * top-level re-exports.
+ */
+const _defaultRegistry = createCronRegistry()
+
+/** @deprecated Use {@link createCronRegistry} — each silgi instance owns its own. */
+export const startCronJobs = _defaultRegistry.start
+/** @deprecated Use {@link createCronRegistry} — each silgi instance owns its own. */
+export const stopCronJobs = _defaultRegistry.stop
+/** @deprecated Use {@link createCronRegistry} — each silgi instance owns its own. */
+export const getScheduledTasks = _defaultRegistry.list

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -10,9 +10,32 @@
  * Returns the path portion without query string.
  *
  * Uses manual indexOf — no `new URL()` overhead.
+ *
+ * @remarks
+ * Handles both absolute URLs (`http://host/path?q`) and bare paths
+ * (`/path?q`). The latter shape is produced by adapters that strip the
+ * origin before calling the handler, and by test harnesses constructing
+ * synthetic requests. Without the bare-path branch, a missing `//`
+ * caused `indexOf('//') + 2 = 1` and `indexOf('/', 1)` returned a bogus
+ * offset that silently produced the wrong path.
  */
 export function parseUrlPath(url: string): string {
-  const pathStart = url.indexOf('/', url.indexOf('//') + 2)
+  // Bare-path fast path — no scheme, no authority.
+  if (url.length > 0 && url.charCodeAt(0) === 47 /* '/' */) {
+    const qMark = url.indexOf('?')
+    return qMark === -1 ? url : url.slice(0, qMark)
+  }
+  const schemeEnd = url.indexOf('//')
+  if (schemeEnd === -1) {
+    // Not a URL we can parse — treat the whole string as the path.
+    const qMark = url.indexOf('?')
+    return qMark === -1 ? url : url.slice(0, qMark)
+  }
+  const pathStart = url.indexOf('/', schemeEnd + 2)
+  if (pathStart === -1) {
+    // URL with authority but no path (e.g. `http://host`). Treat as root.
+    return '/'
+  }
   const qMark = url.indexOf('?', pathStart)
   return qMark === -1 ? url.slice(pathStart) : url.slice(pathStart, qMark)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,12 +114,13 @@ export type { StorageConfig, Storage, StorageValue, Driver } from './core/storag
 export {
   runTask,
   collectCronTasks,
+  createCronRegistry,
   startCronJobs,
   stopCronJobs,
   setTaskAnalytics,
   getScheduledTasks,
 } from './core/task.ts'
-export type { TaskDef, TaskEvent, ScheduledTaskInfo } from './core/task.ts'
+export type { TaskDef, TaskEvent, ScheduledTaskInfo, CronRegistry } from './core/task.ts'
 
 // ── Server ─────────────────────────────────────────
 export type { SilgiServer, ServeOptions } from './core/serve.ts'

--- a/src/integrations/better-auth/index.ts
+++ b/src/integrations/better-auth/index.ts
@@ -53,6 +53,14 @@ function runWithCtx<T>(ctx: Record<string, unknown>, fn: () => T): T {
  * Keyed on `Request` identity. GC-friendly: entry auto-released when the
  * `Request` is collected.
  *
+ * @remarks
+ * This is a documented exception to ARCHITECTURE §3 ("no WeakMap keyed on
+ * Request identity"). Kept only because `setRequestContext` is a public
+ * API consumed by user code outside silgi's control — removing it is a
+ * breaking change reserved for the next major. New integrations must
+ * use `silgi.runInContext(ctx, fn)` or the per-plugin closure pattern
+ * (see `requestMetas` inside `tracing()` below).
+ *
  * @internal
  */
 const _requestContextMap = new WeakMap<Request, Record<string, unknown>>()
@@ -226,10 +234,6 @@ function extractUserData(returned: any): { userId?: string; userEmail?: string; 
   return result
 }
 
-// ── WeakMap for per-request metadata ─────────────────
-
-const requestMetas = new WeakMap<Request, RequestMeta>()
-
 // ── Plugin Factory ───────────────────────────────────
 
 /**
@@ -243,6 +247,13 @@ export function tracing(config?: TracingConfig): any {
   const captureInput = config?.captureInput ?? true
   const captureOutput = config?.captureOutput ?? true
   const wrapMiddleware = config?.createAuthMiddleware ?? ((fn: any) => fn)
+
+  // Per-plugin request metadata — scoped to this `tracing()` call, so two
+  // auth instances running side-by-side never observe each other's state.
+  // Still a WeakMap<Request> because better-auth's onRequest and hooks.after
+  // receive separate contexts but share the same `Request` identity; the
+  // module-global version was a §3 violation, this closure version is not.
+  const requestMetas = new WeakMap<Request, RequestMeta>()
 
   return {
     id: 'silgi-tracing',

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -83,11 +83,19 @@ export async function resolveLazy(value: LazyRouter): Promise<RouterDef | Proced
 
   let pending = loading.get(value)
   if (!pending) {
-    pending = value.load().then((mod) => {
-      resolved.set(value, mod.default)
-      loading.delete(value)
-      return mod.default
-    })
+    pending = value.load().then(
+      (mod) => {
+        resolved.set(value, mod.default)
+        loading.delete(value)
+        return mod.default
+      },
+      (err) => {
+        // Transient import errors must not wedge the router forever.
+        // Clear the in-flight slot so the next caller can retry.
+        loading.delete(value)
+        throw err
+      },
+    )
     loading.set(value, pending)
   }
   return pending

--- a/src/map-input.ts
+++ b/src/map-input.ts
@@ -28,13 +28,15 @@ import type { WrapDef } from './types.ts'
 /**
  * Create a wrap that transforms the procedure input before execution.
  *
- * The mapper function receives the raw input and returns the transformed input.
- * The mapped input is set on the context as `__mappedInput` and picked up
- * by the pipeline.
+ * @remarks
+ * The mapper receives the raw input and returns the transformed input.
+ * Internally this wrap replaces the value in the pipeline's `RAW_INPUT`
+ * symbol slot on `ctx`; the resolver reads the same slot to get the
+ * rewritten input. Users never interact with the slot directly — it's
+ * framework-internal (see `src/core/ctx-symbols.ts`).
  *
- * Note: Since Silgi's pipeline receives input as a separate argument
- * (not on ctx), mapInput works as a wrap that intercepts and transforms
- * before calling next().
+ * Must run inside the wrap onion (not as a guard) so it can observe and
+ * mutate the already-parsed input after schema validation.
  */
 export function mapInput<TIn = unknown, TOut = unknown>(mapper: (input: TIn) => TOut | Promise<TOut>): WrapDef {
   return {

--- a/src/plugins/analytics/routes.ts
+++ b/src/plugins/analytics/routes.ts
@@ -134,6 +134,23 @@ function jsonResponse(data: unknown, headers: HeadersInit): Response {
   return new Response(JSON.stringify(data), { headers })
 }
 
+/**
+ * Parse a request body as JSON without throwing. Returns `null` on any
+ * failure (empty body, malformed JSON, non-JSON content). Used by the
+ * analytics hidden-paths endpoint so a bad request produces a 400 instead
+ * of an uncaught exception that surfaces as a 500 to the client.
+ */
+async function parseJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const text = await request.text()
+    if (!text) return null
+    const parsed = JSON.parse(text)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
 // ── Main Router ─────────────────────────────────────
 
 /** Serve analytics dashboard and API routes. */
@@ -157,20 +174,16 @@ export async function serveAnalyticsRoute(
     if (request.method === 'GET') {
       return jsonResponse(collector.getHiddenPaths(), jsonCacheHeaders)
     }
-    if (request.method === 'POST') {
-      const body = (await request.json()) as { path?: string }
-      if (typeof body.path !== 'string')
+    if (request.method === 'POST' || request.method === 'DELETE') {
+      const body = await parseJsonBody(request)
+      if (!body || typeof body.path !== 'string') {
         return new Response('{"error":"path required"}', { status: 400, headers: jsonCacheHeaders })
-      collector.addHiddenPath(body.path)
+      }
+      if (request.method === 'POST') collector.addHiddenPath(body.path)
+      else collector.removeHiddenPath(body.path)
       return jsonResponse(collector.getHiddenPaths(), jsonCacheHeaders)
     }
-    if (request.method === 'DELETE') {
-      const body = (await request.json()) as { path?: string }
-      if (typeof body.path !== 'string')
-        return new Response('{"error":"path required"}', { status: 400, headers: jsonCacheHeaders })
-      collector.removeHiddenPath(body.path)
-      return jsonResponse(collector.getHiddenPaths(), jsonCacheHeaders)
-    }
+    return new Response('{"error":"method not allowed"}', { status: 405, headers: jsonCacheHeaders })
   }
   if (pathname === 'api/analytics/errors') {
     const errors = (await collector.getErrors()).filter((e) => !collector.isHidden(e.procedure))

--- a/src/plugins/cache.ts
+++ b/src/plugins/cache.ts
@@ -49,16 +49,23 @@ function ensureStorageConnected(): void {
   if (_storageConnected) return
   _storageConnected = true
   try {
-    // Connect ocache to silgi's storage under the 'cache' mount
+    // Connect ocache to silgi's storage under the 'cache' mount.
+    // Each op returns the underlying Promise so ocache can await writes
+    // and surface errors. The prior impl returned void, hiding storage
+    // failures entirely — a Redis/SET timeout silently looked like a
+    // successful cache write and the entry was never persisted.
     const storage = useStorage('cache')
     setStorage({
       get: <T>(key: string) => storage.getItem(key) as Promise<T | null>,
       set: <T>(key: string, value: T, opts?: { ttl?: number }) => {
         if (value === null || value === undefined) {
-          storage.removeItem(key)
-          return
+          return storage.removeItem(key) as unknown as Promise<void>
         }
-        storage.setItem(key, value as string, opts?.ttl ? { ttl: opts.ttl } : undefined)
+        return storage.setItem(
+          key,
+          value as string,
+          opts?.ttl ? { ttl: opts.ttl } : undefined,
+        ) as unknown as Promise<void>
       },
     })
   } catch {
@@ -334,11 +341,12 @@ export function createUnstorageAdapter(storage: UnstorageCompatible): StorageInt
   return {
     get: <T>(key: string) => storage.getItem<T>(key),
     set: <T>(key: string, value: T, opts?: { ttl?: number }) => {
+      // Return the underlying Promise so ocache can await writes and
+      // surface storage errors (Redis timeouts, quota exceeded, etc.).
       if (value === null || value === undefined) {
-        storage.removeItem(key)
-        return
+        return storage.removeItem(key) as unknown as Promise<void>
       }
-      storage.setItem(key, value, opts)
+      return storage.setItem(key, value, opts) as unknown as Promise<void>
     },
   }
 }

--- a/src/plugins/coerce.ts
+++ b/src/plugins/coerce.ts
@@ -5,17 +5,33 @@
  * query parameters. This wrap coerces common types automatically:
  * "123" → 123, "true" → true, "null" → null, etc.
  *
+ * @remarks
+ * **Ordering caveat.** The pipeline validates `$input` schemas *before*
+ * running the wrap onion. That means a plain `z.number()` rejects "123"
+ * before this wrap can see it. You have three options:
+ *
+ * 1. **Use Zod's own coercion** — `z.coerce.number()`, `z.coerce.boolean()`.
+ *    Zero extra wrap, works for simple cases.
+ * 2. **Skip the input schema and validate inside the resolver** — pairs
+ *    naturally with `coerceGuard` because the wrap always runs first.
+ * 3. **Use a string-accepting schema and coerce with `.transform()`** —
+ *    e.g. `z.object({ id: z.string().transform(Number) })`. Again no
+ *    wrap needed.
+ *
+ * `coerceGuard` itself is useful when you have NO input schema but still
+ * want `"42"` / `"true"` / `"null"` normalised before your resolver runs.
+ *
  * @example
  * ```ts
- * import { coerceGuard } from "silgi/plugins"
- *
+ * // Works: no schema → wrap can reshape freely.
  * const getUser = k
  *   .$use(coerceGuard)
- *   .$input(z.object({ id: z.number(), active: z.boolean().optional() }))
- *   .$resolve(({ input }) => db.users.find(input.id))
+ *   .$resolve(({ input }) => db.users.find((input as any).id))
  *
- * // GET /users/get?data={"id":"42","active":"true"}
- * // → input is coerced to { id: 42, active: true }
+ * // Works: schema uses z.coerce.
+ * const getUser2 = k
+ *   .$input(z.object({ id: z.coerce.number() }))
+ *   .$resolve(({ input }) => db.users.find(input.id))
  * ```
  */
 
@@ -35,8 +51,9 @@ import type { WrapDef } from '../types.ts'
  * - "" → undefined (empty strings become undefined)
  * - Everything else → kept as-is
  *
- * Implemented as a wrap (not a guard) so it runs after __rawInput is populated
- * by the pipeline compiler.
+ * Implemented as a wrap so it runs after the pipeline has populated the
+ * `RAW_INPUT` slot on ctx — see the caveat in the top-level docstring
+ * about ordering vs. input schema validation.
  */
 export const coerceGuard: WrapDef<Record<string, unknown>> = {
   kind: 'wrap',

--- a/src/silgi.ts
+++ b/src/silgi.ts
@@ -647,7 +647,13 @@ export function silgi<TBaseCtx extends Record<string, unknown>>(
         bridge as import('./core/context-bridge.ts').ContextBridge,
       )
 
-      // Auto-discover and start cron tasks from router
+      // Auto-discover and start cron tasks from router.
+      // NOTE: currently uses the process-default registry so the analytics
+      // dashboard (which reads `getScheduledTasks()` via the same default)
+      // keeps showing scheduled jobs. `createCronRegistry()` is exported
+      // for users who want fully-isolated registries; a future refactor
+      // will thread that registry through the analytics route so this
+      // serve() can drop to per-instance.
       const { collectCronTasks, startCronJobs, stopCronJobs } = await import('./core/task.ts')
       const cronTasks = collectCronTasks(routerDef)
       if (cronTasks.length > 0) {

--- a/src/silgi.ts
+++ b/src/silgi.ts
@@ -16,6 +16,7 @@ import { createProcedureBuilder } from './builder.ts'
 import { createCaller } from './caller.ts'
 import { compileRouter } from './compile.ts'
 import { createContextBridge } from './core/context-bridge.ts'
+import { ROOT_WRAPS } from './core/ctx-symbols.ts'
 import { createFetchHandler, wrapHandler } from './core/handler.ts'
 import { assignPaths, routerCache } from './core/router-utils.ts'
 import { createSchemaRegistry } from './core/schema-converter.ts'
@@ -36,6 +37,7 @@ import type {
   ProcedureType,
   ErrorDef,
   GuardDef,
+  MiddlewareDef,
   WrapDef,
   GuardFn,
   WrapFn,
@@ -101,6 +103,41 @@ export interface SilgiConfig<TCtx extends Record<string, unknown>> {
    * ```
    */
   schemaConverters?: SchemaConverter[]
+  /**
+   * Root-level wrap middleware applied to every procedure in the router.
+   *
+   * @remarks
+   * Each entry must be created via `instance.wrap(fn)`. Root wraps run
+   * as the outermost layer of the onion: root wraps → route-level
+   * `.$use()` guards/wraps → resolver. Use this for concerns that must
+   * apply to every route (tenant scoping, `AsyncLocalStorage` setup,
+   * trace propagation), where missing one route would be a bug.
+   *
+   * Root wraps cannot mutate the context type — use a route-level
+   * `$use(guard)` for that. The ambient context passed to `next()` is
+   * `TBaseCtx`, identical to the one seen by route-level wraps.
+   *
+   * Applies to every procedure reachable through `handler()`,
+   * `createCaller()`, and HTTP/cron task invocation. Task `dispatch()`
+   * (programmatic, bypasses the pipeline) is not wrapped.
+   *
+   * @example
+   * ```ts
+   * const tenantScopeWrap: WrapDef = {
+   *   kind: 'wrap',
+   *   fn: (ctx, next) => tenantScope.run({ orgId: ctx.user.orgId }, next),
+   * }
+   *
+   * const s = silgi({
+   *   context: (req) => ({ db, user: readUser(req) }),
+   *   wraps: [tenantScopeWrap],
+   * })
+   * ```
+   *
+   * For convenience you can also create wraps with the standalone
+   * helper or from another silgi instance's `wrap()` method.
+   */
+  wraps?: WrapDef<TCtx>[]
   /**
    * Storage configuration — mount drivers by path prefix.
    *
@@ -363,6 +400,31 @@ function createProcedure(type: ProcedureType, ...args: unknown[]): ProcedureDef 
 }
 
 /**
+ * Stamp root wraps onto a router def as a non-enumerable Symbol-keyed
+ * property. Idempotent — if the def is already branded with the same
+ * reference, this is a no-op. Multiple silgi instances registering the
+ * same def throws, because a single compiled router cannot serve two
+ * context shapes.
+ *
+ * @internal
+ */
+function stampRootWraps(def: object, wraps: readonly WrapDef[]): void {
+  const existing = (def as { [ROOT_WRAPS]?: readonly WrapDef[] })[ROOT_WRAPS]
+  if (existing === wraps) return
+  if (existing) {
+    throw new TypeError(
+      'silgi: this router def is already registered with a different silgi instance — build a fresh router object.',
+    )
+  }
+  Object.defineProperty(def, ROOT_WRAPS, {
+    value: wraps,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  })
+}
+
+/**
  * Create a Silgi RPC instance with typed context.
  *
  * @remarks
@@ -432,6 +494,26 @@ export function silgi<TBaseCtx extends Record<string, unknown>>(
 
   const ctxFactory = () => contextFactory(new Request('http://localhost'))
 
+  // Freeze root wraps once so routers built later share the same reference.
+  // Enforce WrapDef shape — guards are rejected because they would need to
+  // flow their return type into every procedure's context, which can't be
+  // expressed at the instance-config type level.
+  let rootWraps: readonly WrapDef[] | null = null
+  if (config.wraps && config.wraps.length > 0) {
+    for (const w of config.wraps) {
+      if (!w || (w as MiddlewareDef).kind !== 'wrap') {
+        throw new TypeError('silgi({ wraps }) only accepts wrap middleware — use route-level .$use() for guards.')
+      }
+    }
+    rootWraps = Object.freeze([...config.wraps]) as readonly WrapDef[]
+  }
+
+  // Lazy getter handed to tasks so `task.dispatch()` applies the same
+  // root-wrap onion as HTTP/cron invocation. Null when no wraps configured
+  // — task dispatch stays a straight `await resolveFn(...)` with zero
+  // additional closure.
+  const rootWrapsGetter: (() => readonly WrapDef[] | null) | null = rootWraps ? () => rootWraps : null
+
   const instance: SilgiInstance<TBaseCtx> = {
     hook: hooks.hook.bind(hooks),
     removeHook: hooks.removeHook.bind(hooks),
@@ -452,25 +534,37 @@ export function silgi<TBaseCtx extends Record<string, unknown>>(
     wrap: (fn) => ({ kind: 'wrap' as const, fn }),
 
     $resolve: ((fn: any) => createProcedure('query', fn)) as any,
-    $input: ((schema: any) => createProcedureBuilder('query', ctxFactory).$input(schema)) as any,
+    $input: ((schema: any) => createProcedureBuilder('query', ctxFactory, rootWrapsGetter).$input(schema)) as any,
     $use: ((...middleware: any[]) => {
-      const b = createProcedureBuilder('query', ctxFactory) as any
+      const b = createProcedureBuilder('query', ctxFactory, rootWrapsGetter) as any
       for (const m of middleware) b.$use(m)
       return b
     }) as any,
-    $output: ((schema: any) => createProcedureBuilder('query', ctxFactory).$output(schema)) as any,
-    $errors: ((errors: any) => createProcedureBuilder('query', ctxFactory).$errors(errors)) as any,
-    $route: ((route: any) => createProcedureBuilder('query', ctxFactory).$route(route)) as any,
-    $meta: ((meta: any) => createProcedureBuilder('query', ctxFactory).$meta(meta)) as any,
+    $output: ((schema: any) => createProcedureBuilder('query', ctxFactory, rootWrapsGetter).$output(schema)) as any,
+    $errors: ((errors: any) => createProcedureBuilder('query', ctxFactory, rootWrapsGetter).$errors(errors)) as any,
+    $route: ((route: any) => createProcedureBuilder('query', ctxFactory, rootWrapsGetter).$route(route)) as any,
+    $meta: ((meta: any) => createProcedureBuilder('query', ctxFactory, rootWrapsGetter).$meta(meta)) as any,
 
     subscription: ((...args: unknown[]) => createProcedure('subscription', ...args)) as SubscriptionFactory<TBaseCtx>,
 
     $task: ((config: any) => {
-      return createTaskFromProcedure(config, config.resolve, null, null, ctxFactory)
+      return createTaskFromProcedure(config, config.resolve, null, null, ctxFactory, rootWrapsGetter)
     }) as any,
 
     router: (def) => {
       const assigned = assignPaths(def)
+      // Brand the def with this instance's root wraps (if any) so every
+      // downstream compile site — handler(), createCaller(), auto-WS, and
+      // external adapters (Express, Lambda, NestJS, message-port, broker,
+      // batch-server, server-client) — picks them up automatically via
+      // `compileRouter` reading `def[ROOT_WRAPS]`. The brand is a non-
+      // enumerable Symbol, so `Object.entries(def)` in the router walker
+      // never sees it. When `rootWraps` is null we don't stamp anything,
+      // so the def is byte-identical to the pre-feature shape.
+      if (rootWraps) {
+        stampRootWraps(def, rootWraps)
+        stampRootWraps(assigned, rootWraps)
+      }
       const flat = compileRouter(assigned)
       // Cache against the original def — don't mutate user's object
       routerCache.set(def, flat)

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -78,12 +78,6 @@ interface RPCRequest {
   input?: unknown
 }
 
-// Track active AbortControllers per peer for cleanup on disconnect
-const peerAbortControllers = new WeakMap<Peer, Set<AbortController>>()
-
-// Track keepalive timers per peer for cleanup on disconnect
-const peerKeepaliveTimers = new WeakMap<Peer, ReturnType<typeof setInterval>>()
-
 /**
  * Internal — build crossws-compatible hooks for Silgi RPC over WebSocket.
  *
@@ -99,6 +93,14 @@ export function _createWSHooks<TCtx extends Record<string, unknown>>(
   const useMsgpack = options.protocol === 'messagepack' || (options.protocol == null && (options.binary ?? false))
   const contextFactory = options.context
   const keepaliveMs = options.keepalive === false ? 0 : (options.keepalive ?? 30_000)
+
+  // Per-hookset registries — closed over by the returned open/message/close
+  // handlers. Scoped here (not module-global) so two silgi instances sharing
+  // a process cannot scribble into each other's peer state. Keys are the
+  // Peer objects crossws hands us; GC releases entries when the peer is
+  // collected, same as WeakMap semantics dictate.
+  const peerAbortControllers = new WeakMap<Peer, Set<AbortController>>()
+  const peerKeepaliveTimers = new WeakMap<Peer, ReturnType<typeof setInterval>>()
 
   function send(peer: Peer, data: unknown): void {
     const compress = !!options.compress

--- a/test/adapters/lambda.test.ts
+++ b/test/adapters/lambda.test.ts
@@ -57,4 +57,22 @@ describe('createHandler()', () => {
     expect(result.statusCode).toBe(200)
     expect(JSON.parse(result.body)).toEqual({ ok: true })
   })
+
+  it('does not strip prefix that only matches as substring', async () => {
+    // `/api2/health` must NOT be treated as `/health` when prefix is `/api`.
+    // The previous impl used `startsWith(prefix)` without a segment boundary
+    // check and silently routed the wrong path.
+    const router = k.router({ health: k.$resolve(() => ({ ok: true })) })
+    const handler = createHandler(router, { prefix: '/api', context: () => ({}) })
+
+    const result = await handler({
+      httpMethod: 'POST',
+      path: '/api2/health',
+      body: null,
+      headers: {},
+      queryStringParameters: null,
+    })
+
+    expect(result.statusCode).toBe(404)
+  })
 })

--- a/test/client/retry.test.ts
+++ b/test/client/retry.test.ts
@@ -119,6 +119,35 @@ describe('withRetry', () => {
     const retryLink = withRetry(link, { baseDelay: () => 5 })
     expect(await retryLink.call(['test'], undefined, {})).toBe('ok')
   })
+
+  it('does not leak abort listeners on long-lived signals', async () => {
+    // Simulate a page-level AbortController reused across many retry waves.
+    // Prior impl added a new `abort` listener on every retry and never
+    // removed them when the retry timer fired, so the signal slowly
+    // accumulated listeners.
+    const controller = new AbortController()
+    const addSpy = vi.spyOn(controller.signal, 'addEventListener')
+    const removeSpy = vi.spyOn(controller.signal, 'removeEventListener')
+
+    // 3 retries per call → 3 adds + 3 removes per call.
+    for (let i = 0; i < 3; i++) {
+      const link = mockLink([
+        { error: errorWithStatus(500) },
+        { error: errorWithStatus(500) },
+        { error: errorWithStatus(500) },
+        { value: 'ok' },
+      ])
+      const retryLink = withRetry(link, { baseDelay: 1, jitter: false, maxRetries: 3 })
+      await retryLink.call(['test'], undefined, { signal: controller.signal })
+    }
+
+    // Each retry adds exactly one listener and removes it on timer fire —
+    // net adds must equal net removes.
+    const abortAdds = addSpy.mock.calls.filter(([ev]) => ev === 'abort').length
+    const abortRemoves = removeSpy.mock.calls.filter(([ev]) => ev === 'abort').length
+    expect(abortAdds).toBeGreaterThan(0)
+    expect(abortRemoves).toBe(abortAdds)
+  })
 })
 
 // ── withCircuitBreaker ──

--- a/test/core/caller.test.ts
+++ b/test/core/caller.test.ts
@@ -212,6 +212,25 @@ describe('createCaller', () => {
     expect(result.status).toBe('ok')
   })
 
+  it('null timeout still hands resolvers a real AbortSignal — not undefined', async () => {
+    // Regression: old impl passed `undefined as AbortSignal`; any resolver
+    // that read `signal.aborted` or `signal.addEventListener` NPE'd.
+    const sigS = silgi({ context: () => ({}) })
+    const sigRouter = sigS.router({
+      peek: sigS.$resolve(({ signal }) => {
+        // Both reads must succeed without throwing
+        const aborted = signal.aborted
+        let listenerAttached = false
+        signal.addEventListener('abort', () => {}, { once: true })
+        listenerAttached = true
+        return { aborted, listenerAttached, hasSignal: signal instanceof AbortSignal }
+      }),
+    })
+    const caller = sigS.createCaller(sigRouter, { timeout: null })
+    const out = await caller.peek()
+    expect(out).toEqual({ aborted: false, listenerAttached: true, hasSignal: true })
+  })
+
   it('passes signal to handler', async () => {
     const signalS = silgi({ context: () => ({}) })
     const signalRouter = signalS.router({

--- a/test/core/lazy.test.ts
+++ b/test/core/lazy.test.ts
@@ -47,4 +47,42 @@ describe('resolveLazy', () => {
     const l = lazy(() => Promise.reject(new Error('import failed')))
     await expect(resolveLazy(l)).rejects.toThrow('import failed')
   })
+
+  it('does not cache rejections — retries succeed after a transient failure', async () => {
+    const routerDef = { hello: { type: 'query', resolve: () => 'hi' } }
+    let attempt = 0
+    const loader = vi.fn(() => {
+      attempt++
+      if (attempt === 1) return Promise.reject(new Error('transient'))
+      return Promise.resolve({ default: routerDef })
+    })
+    const l = lazy(loader)
+
+    await expect(resolveLazy(l)).rejects.toThrow('transient')
+    // Second call must retry — not see the cached rejection
+    const result = await resolveLazy(l)
+    expect(result).toBe(routerDef)
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  it('concurrent callers during a rejection all see the error, then next call retries', async () => {
+    let attempt = 0
+    const loader = vi.fn(() => {
+      attempt++
+      if (attempt === 1) return Promise.reject(new Error('boom'))
+      return Promise.resolve({ default: { ok: true } as any })
+    })
+    const l = lazy(loader)
+
+    // Two concurrent calls share the first in-flight rejection
+    const [a, b] = await Promise.allSettled([resolveLazy(l), resolveLazy(l)])
+    expect(a.status).toBe('rejected')
+    expect(b.status).toBe('rejected')
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    // After settle, a fresh call retries
+    const ok = await resolveLazy(l)
+    expect((ok as any).ok).toBe(true)
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
 })

--- a/test/core/root-wraps.test.ts
+++ b/test/core/root-wraps.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect } from 'vitest'
+
+import { silgi } from '#src/silgi.ts'
+
+describe('silgi({ wraps })', () => {
+  it('applies a root wrap to every procedure', async () => {
+    const order: string[] = []
+
+    const k = silgi({
+      context: () => ({ db: 'x' }),
+    })
+    const rootWrap = k.wrap(async (_ctx, next) => {
+      order.push('root:before')
+      const out = await next()
+      order.push('root:after')
+      return out
+    })
+
+    const s = silgi({
+      context: () => ({ db: 'x' }),
+      wraps: [rootWrap],
+    })
+
+    const r = s.router({
+      hello: s.$resolve(() => {
+        order.push('resolve')
+        return 'hi'
+      }),
+      nested: {
+        bye: s.$resolve(() => 'bye'),
+      },
+    })
+
+    const caller = s.createCaller(r)
+    const out = await caller.hello()
+    expect(out).toBe('hi')
+    expect(order).toEqual(['root:before', 'resolve', 'root:after'])
+
+    order.length = 0
+    await caller.nested.bye()
+    expect(order).toEqual(['root:before', 'root:after'])
+  })
+
+  it('root wraps are outermost — route-level $use nests inside', async () => {
+    const order: string[] = []
+
+    const probe = silgi({ context: () => ({}) })
+
+    const rootWrap = probe.wrap(async (_ctx, next) => {
+      order.push('root:before')
+      const out = await next()
+      order.push('root:after')
+      return out
+    })
+
+    const routeWrap = probe.wrap(async (_ctx, next) => {
+      order.push('route:before')
+      const out = await next()
+      order.push('route:after')
+      return out
+    })
+
+    const s = silgi({
+      context: () => ({}),
+      wraps: [rootWrap],
+    })
+
+    const r = s.router({
+      hello: s.$use(routeWrap).$resolve(() => {
+        order.push('resolve')
+        return 'ok'
+      }),
+    })
+
+    const caller = s.createCaller(r)
+    await caller.hello()
+    expect(order).toEqual(['root:before', 'route:before', 'resolve', 'route:after', 'root:after'])
+  })
+
+  it('multiple root wraps run in declared order (first = outermost)', async () => {
+    const order: string[] = []
+    const probe = silgi({ context: () => ({}) })
+
+    const outer = probe.wrap(async (_ctx, next) => {
+      order.push('outer:before')
+      const o = await next()
+      order.push('outer:after')
+      return o
+    })
+    const inner = probe.wrap(async (_ctx, next) => {
+      order.push('inner:before')
+      const o = await next()
+      order.push('inner:after')
+      return o
+    })
+
+    const s = silgi({
+      context: () => ({}),
+      wraps: [outer, inner],
+    })
+
+    const r = s.router({
+      hello: s.$resolve(() => 'ok'),
+    })
+
+    await s.createCaller(r).hello()
+    expect(order).toEqual(['outer:before', 'inner:before', 'inner:after', 'outer:after'])
+  })
+
+  it('root wrap can short-circuit without calling next()', async () => {
+    const probe = silgi({ context: () => ({}) })
+    const shortCircuit = probe.wrap(async () => 'short-circuited')
+
+    const s = silgi({
+      context: () => ({}),
+      wraps: [shortCircuit],
+    })
+
+    const r = s.router({
+      hello: s.$resolve(() => 'never'),
+    })
+
+    const out = await s.createCaller(r).hello()
+    expect(out).toBe('short-circuited')
+  })
+
+  it('root wraps are applied via the HTTP handler too', async () => {
+    const calls: string[] = []
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => {
+      calls.push('wrap')
+      return next()
+    })
+
+    const s = silgi({
+      context: () => ({ n: 1 }),
+      wraps: [w],
+    })
+
+    const r = s.router({
+      ping: s.$resolve(() => 'pong'),
+    })
+
+    const handler = s.handler(r)
+    const res = await handler(new Request('http://localhost/ping', { method: 'POST' }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBe('pong')
+    expect(calls).toEqual(['wrap'])
+  })
+
+  it('rejects non-wrap middleware in config.wraps', () => {
+    const probe = silgi({ context: () => ({}) })
+    const g = probe.guard(() => ({ x: 1 }))
+
+    expect(() =>
+      silgi({
+        context: () => ({}),
+        wraps: [g as any],
+      }),
+    ).toThrow(/wrap middleware/)
+  })
+
+  it('omitting wraps behaves identically to the previous API', async () => {
+    const s = silgi({ context: () => ({}) })
+    const r = s.router({ hello: s.$resolve(() => 'ok') })
+    const out = await s.createCaller(r).hello()
+    expect(out).toBe('ok')
+  })
+
+  it('ctx passed to root wrap reflects base context', async () => {
+    const probe = silgi({ context: () => ({}) })
+    const seen: Record<string, unknown>[] = []
+    const spy = probe.wrap(async (ctx, next) => {
+      seen.push({ ...ctx })
+      return next()
+    })
+
+    const s = silgi({
+      context: () => ({ tenant: 'acme' }),
+      wraps: [spy],
+    })
+
+    const r = s.router({ hello: s.$resolve(() => 'ok') })
+    await s.createCaller(r).hello()
+    expect(seen[0]).toMatchObject({ tenant: 'acme' })
+  })
+
+  it('external adapter — compileRouter reads the ROOT_WRAPS brand off the user def', async () => {
+    const calls: string[] = []
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => {
+      calls.push('wrap')
+      return next()
+    })
+
+    const s = silgi({
+      context: () => ({}),
+      wraps: [w],
+    })
+
+    // Simulating an adapter that receives the user's RouterDef and compiles
+    // it directly without consulting routerCache (express, lambda, nestjs,
+    // message-port, batch-server, broker, client/server all do this).
+    const { compileRouter } = await import('#src/compile.ts')
+    const r = s.router({ hello: s.$resolve(() => 'ok') })
+    const flat = compileRouter(r)
+    const match = flat('', '/hello')
+    expect(match).toBeDefined()
+    const ctx: any = {}
+    await match!.data.handler(ctx, undefined, AbortSignal.timeout(5000))
+    expect(calls).toEqual(['wrap'])
+  })
+
+  it('WS path — _createWSHooks gets wraps via compileRouter reading brand off def', async () => {
+    // The auto-WS inside silgi.handler() passes the original user def to
+    // `_createWSHooks`. `_createWSHooks` in turn calls compileRouter(def).
+    // Since the brand lives on the def, wraps flow through automatically.
+    const calls: string[] = []
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => {
+      calls.push('wrap')
+      return next()
+    })
+
+    const s = silgi({
+      context: () => ({}),
+      wraps: [w],
+    })
+
+    async function* sub() {
+      yield 1
+      yield 2
+    }
+
+    const r = s.router({
+      stream: s.subscription(sub as any),
+    })
+
+    // Verify the brand is present on the user's def
+    const { ROOT_WRAPS } = await import('#src/core/ctx-symbols.ts')
+    expect((r as any)[ROOT_WRAPS]).toBeDefined()
+    expect((r as any)[ROOT_WRAPS]).toHaveLength(1)
+  })
+
+  it('task.dispatch() runs root wraps (no longer bypasses them)', async () => {
+    const order: string[] = []
+    const probe = silgi({ context: () => ({}) })
+    const tenantScope = probe.wrap(async (ctx, next) => {
+      order.push('enter')
+      ;(ctx as any).scoped = true
+      const out = await next()
+      order.push('exit')
+      return out
+    })
+
+    const s = silgi({
+      context: () => ({ db: 'x' }),
+      wraps: [tenantScope],
+    })
+
+    const seenInTask: any = {}
+    const sendEmail = s.$task({
+      name: 'send-email',
+      resolve: ({ ctx }) => {
+        order.push('resolve')
+        seenInTask.scoped = (ctx as any).scoped
+        return { sent: true }
+      },
+    })
+
+    const out = await sendEmail.dispatch()
+    expect(out).toEqual({ sent: true })
+    expect(order).toEqual(['enter', 'resolve', 'exit'])
+    expect(seenInTask.scoped).toBe(true)
+  })
+
+  it('task.dispatch() without wraps stays on the straight path (zero onion)', async () => {
+    const s = silgi({ context: () => ({}) })
+    const t = s.$task({
+      name: 'noop',
+      resolve: () => 'ok',
+    })
+    const out = await t.dispatch()
+    expect(out).toBe('ok')
+  })
+
+  it('cache miss does not silently drop wraps — compileRouter re-reads brand', async () => {
+    // Simulates the `createFetchHandler` fallback path: if `routerCache`
+    // misses (e.g. user never called s.router()), compileRouter runs fresh
+    // but still picks up the brand — IF present. When the user didn't call
+    // s.router() the brand is absent, which is the correct signal to run
+    // wraps-less (matches pre-feature behavior).
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => next())
+    const s = silgi({ context: () => ({}), wraps: [w] })
+
+    const rawDef = { hello: s.$resolve(() => 'ok') }
+    const { compileRouter } = await import('#src/compile.ts')
+
+    // Without s.router(), no brand, wraps don't apply (documented behavior).
+    const flatNoBrand = compileRouter(rawDef)
+    const matchA = flatNoBrand('', '/hello')
+    expect(matchA).toBeDefined()
+
+    // After s.router(), brand is stamped, wraps apply.
+    s.router(rawDef)
+    const flatWithBrand = compileRouter(rawDef)
+    const matchB = flatWithBrand('', '/hello')
+    expect(matchB).toBeDefined()
+  })
+
+  it('re-registering a def with a second silgi instance throws', () => {
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => next())
+
+    const s1 = silgi({ context: () => ({}), wraps: [w] })
+    const s2 = silgi({ context: () => ({}), wraps: [w] })
+
+    const def = { hello: s1.$resolve(() => 'ok') }
+    s1.router(def)
+    expect(() => s2.router(def)).toThrow(/already registered/)
+  })
+
+  it('re-registering a def with the SAME silgi instance is idempotent', () => {
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => next())
+    const s = silgi({ context: () => ({}), wraps: [w] })
+
+    const def = { hello: s.$resolve(() => 'ok') }
+    expect(() => {
+      s.router(def)
+      s.router(def)
+    }).not.toThrow()
+  })
+
+  it('no wraps configured — def is byte-identical to pre-feature shape', () => {
+    const s = silgi({ context: () => ({}) })
+    const def = { hello: s.$resolve(() => 'ok') }
+    s.router(def)
+    const symbols = Object.getOwnPropertySymbols(def)
+    expect(symbols).toHaveLength(0)
+  })
+
+  it('brand is non-enumerable — router walkers never see it', () => {
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => next())
+    const s = silgi({ context: () => ({}), wraps: [w] })
+
+    const def = { a: s.$resolve(() => 1), b: s.$resolve(() => 2) }
+    s.router(def)
+
+    // Object.keys / Object.entries skip Symbol-keyed props
+    expect(Object.keys(def)).toEqual(['a', 'b'])
+    expect(Object.entries(def).map(([k]) => k)).toEqual(['a', 'b'])
+  })
+
+  it('Express adapter picks up wraps via compileRouter without per-adapter plumbing', async () => {
+    const calls: string[] = []
+    const probe = silgi({ context: () => ({}) })
+    const w = probe.wrap(async (_ctx, next) => {
+      calls.push('wrap')
+      return next()
+    })
+
+    const s = silgi({
+      context: () => ({ db: 'x' }),
+      wraps: [w],
+    })
+
+    const r = s.router({
+      ping: s.$resolve(() => 'pong'),
+    })
+
+    const express = (await import('express')).default
+    const { createHandler } = await import('#src/adapters/express.ts')
+
+    const app = express()
+    app.use(express.json())
+    app.use('/rpc', createHandler(r))
+
+    const server = app.listen(0)
+    try {
+      const address = server.address() as { port: number }
+      const res = await fetch(`http://127.0.0.1:${address.port}/rpc/ping`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toBe('pong')
+      expect(calls).toEqual(['wrap'])
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('sync fast path preserved when no root wraps are configured', async () => {
+    // Compile-level assertion — with no wraps, the handler is NOT async.
+    // We detect this by observing that the compiled handler returns a
+    // synchronous (non-Promise) value for a sync resolver, via the sync
+    // fast-path branch in compileProcedure.
+    const s = silgi({ context: () => ({}) })
+    const proc = s.$resolve(() => 'sync')
+    const { compileProcedure } = await import('#src/compile.ts')
+    const handler = compileProcedure(proc as any)
+    const ctx: Record<string, unknown> = {}
+    const result = handler(ctx, undefined, AbortSignal.timeout(5000))
+    expect(result).toBe('sync')
+    expect(result).not.toBeInstanceOf(Promise)
+  })
+})

--- a/test/core/serve-body.test.ts
+++ b/test/core/serve-body.test.ts
@@ -18,9 +18,11 @@ describe('handler() — body parsing safety', () => {
         body: '{broken json',
       }),
     )
-    // Should not crash — should return an error response
-    expect(res.status).toBeGreaterThanOrEqual(400)
-    expect(res.status).toBeLessThan(600)
+    // Must be a 400 — same semantics across Node, Bun, Deno. A silent
+    // undefined would let malformed payloads reach resolvers.
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { code: string }
+    expect(body.code).toBe('BAD_REQUEST')
   })
 
   it('returns 400 for malformed GET ?data= JSON', async () => {

--- a/test/core/serve-body.test.ts
+++ b/test/core/serve-body.test.ts
@@ -31,6 +31,31 @@ describe('handler() — body parsing safety', () => {
     expect(res.status).toBeLessThan(600)
   })
 
+  it('does not match ?userdata= as the data= parameter', async () => {
+    // Regression: old impl used indexOf('data=') which matched any key
+    // ending in "data". The resolver would then parse `"oops"` as input.
+    // Proper impl sees no `data=` parameter at a key boundary → input
+    // stays undefined.
+    const k2 = silgi({ context: () => ({}) })
+    const r = k2.router({ echo2: k2.$resolve(({ input }) => ({ got: input ?? 'no-input' })) })
+    const h = k2.handler(r)
+    const res = await h(new Request('http://localhost/echo2?userdata=%22oops%22', { method: 'POST' }))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { got: unknown }
+    expect(body.got).toBe('no-input')
+  })
+
+  it('correctly parses data= when preceded by other params', async () => {
+    const k2 = silgi({ context: () => ({}) })
+    const r = k2.router({ echo3: k2.$resolve(({ input }) => ({ got: input })) })
+    const h = k2.handler(r)
+    const encoded = encodeURIComponent(JSON.stringify({ n: 42 }))
+    const res = await h(new Request(`http://localhost/echo3?other=x&data=${encoded}`))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { got: unknown }
+    expect(body.got).toEqual({ n: 42 })
+  })
+
   it('handles UTF-8 multibyte response correctly', async () => {
     const k2 = silgi({ context: () => ({}) })
     const r = k2.router({

--- a/test/core/task.test.ts
+++ b/test/core/task.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, expectTypeOf, afterEach } from 'vitest'
 import { z } from 'zod'
 
-import { runTask, collectCronTasks, setTaskAnalytics } from '#src/core/task.ts'
+import { runTask, collectCronTasks, createCronRegistry, setTaskAnalytics } from '#src/core/task.ts'
 import { silgi } from '#src/silgi.ts'
 
 import type { TaskDef } from '#src/core/task.ts'
@@ -155,6 +155,39 @@ describe('collectCronTasks', () => {
     const noCron = s.$task({ name: 'no-cron', resolve: async () => 'ok' })
     const router = s.router({ tasks: { noCron } })
     expect(collectCronTasks(router)).toHaveLength(0)
+  })
+})
+
+// ── createCronRegistry — per-instance isolation ──────
+
+describe('createCronRegistry()', () => {
+  it('returns an isolated registry — two registries do not share state', async () => {
+    const a = createCronRegistry()
+    const b = createCronRegistry()
+
+    const task = s.$task({ name: 'noop', cron: '0 0 1 1 *', resolve: async () => 'ok' })
+    await a.start([{ cron: '0 0 1 1 *', task }])
+
+    expect(a.list()).toHaveLength(1)
+    expect(b.list()).toHaveLength(0)
+
+    a.stop()
+    expect(a.list()).toHaveLength(0)
+    expect(b.list()).toHaveLength(0)
+  })
+
+  it('stop() clears entries but leaves other registries intact', async () => {
+    const a = createCronRegistry()
+    const b = createCronRegistry()
+
+    const task = s.$task({ name: 'noop2', cron: '0 0 1 1 *', resolve: async () => 'ok' })
+    await a.start([{ cron: '0 0 1 1 *', task }])
+    await b.start([{ cron: '0 0 1 1 *', task }])
+
+    a.stop()
+    expect(a.list()).toHaveLength(0)
+    expect(b.list()).toHaveLength(1)
+    b.stop()
   })
 })
 

--- a/test/core/url.test.ts
+++ b/test/core/url.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePrefix, parseUrlPath, parseUrlPathname } from '#src/core/url.ts'
+
+describe('parseUrlPath', () => {
+  it('extracts path from absolute URL', () => {
+    expect(parseUrlPath('http://localhost/foo/bar')).toBe('/foo/bar')
+    expect(parseUrlPath('https://example.com/a/b')).toBe('/a/b')
+  })
+
+  it('strips query string', () => {
+    expect(parseUrlPath('http://localhost/foo?bar=1')).toBe('/foo')
+    expect(parseUrlPath('http://localhost/a/b?x=1&y=2')).toBe('/a/b')
+  })
+
+  it('handles bare path input — used by test harnesses and prefix-stripping adapters', () => {
+    // Regression: old impl computed `indexOf('//') + 2 = 1` and then
+    // `indexOf('/', 1)`, which silently produced bogus offsets.
+    expect(parseUrlPath('/foo/bar')).toBe('/foo/bar')
+    expect(parseUrlPath('/foo?q=1')).toBe('/foo')
+    expect(parseUrlPath('/')).toBe('/')
+  })
+
+  it('handles URL with authority but no path', () => {
+    expect(parseUrlPath('http://localhost')).toBe('/')
+    expect(parseUrlPath('http://host.example.com')).toBe('/')
+  })
+
+  it('falls back gracefully on unparseable inputs', () => {
+    expect(parseUrlPath('')).toBe('')
+    expect(parseUrlPath('not-a-url')).toBe('not-a-url')
+  })
+})
+
+describe('parseUrlPathname', () => {
+  it('strips the leading slash', () => {
+    expect(parseUrlPathname('http://localhost/foo')).toBe('foo')
+    expect(parseUrlPathname('/foo/bar')).toBe('foo/bar')
+  })
+
+  it('returns empty string for root', () => {
+    expect(parseUrlPathname('http://localhost/')).toBe('')
+    expect(parseUrlPathname('/')).toBe('')
+    expect(parseUrlPathname('http://localhost')).toBe('')
+  })
+})
+
+describe('normalizePrefix', () => {
+  it('ensures leading slash', () => {
+    expect(normalizePrefix('api')).toBe('/api')
+    expect(normalizePrefix('/api')).toBe('/api')
+  })
+
+  it('strips trailing slash', () => {
+    expect(normalizePrefix('/api/')).toBe('/api')
+    expect(normalizePrefix('api/')).toBe('/api')
+  })
+
+  it('preserves single slash', () => {
+    // Pathological — degenerates to empty string. Test documents behavior.
+    expect(normalizePrefix('/')).toBe('')
+  })
+})

--- a/test/plugins/analytics.test.ts
+++ b/test/plugins/analytics.test.ts
@@ -816,4 +816,35 @@ describe('hidden paths API', () => {
 
     await c.dispose()
   })
+
+  it('returns 400 (not an uncaught 500) for malformed JSON body', async () => {
+    const c = new AnalyticsCollector({ flushInterval: 999_999 })
+    const req = new Request('http://localhost/api/analytics/hidden', {
+      method: 'POST',
+      body: '{not json',
+      headers: { 'content-type': 'application/json' },
+    })
+    const res = await serveAnalyticsRoute('api/analytics/hidden', req, c, undefined)
+    expect(res.status).toBe(400)
+    await c.dispose()
+  })
+
+  it('returns 400 for empty body', async () => {
+    const c = new AnalyticsCollector({ flushInterval: 999_999 })
+    const req = new Request('http://localhost/api/analytics/hidden', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    })
+    const res = await serveAnalyticsRoute('api/analytics/hidden', req, c, undefined)
+    expect(res.status).toBe(400)
+    await c.dispose()
+  })
+
+  it('returns 405 for unsupported method on /hidden', async () => {
+    const c = new AnalyticsCollector({ flushInterval: 999_999 })
+    const req = new Request('http://localhost/api/analytics/hidden', { method: 'PUT' })
+    const res = await serveAnalyticsRoute('api/analytics/hidden', req, c, undefined)
+    expect(res.status).toBe(405)
+    await c.dispose()
+  })
 })

--- a/test/plugins/coerce.test.ts
+++ b/test/plugins/coerce.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { coerceGuard, coerceObject, coerceValue } from '#src/plugins/coerce.ts'
+import { silgi } from '#src/silgi.ts'
+
+describe('coerceValue', () => {
+  it('coerces numeric strings to numbers', () => {
+    expect(coerceValue('42')).toBe(42)
+    expect(coerceValue('-7')).toBe(-7)
+    expect(coerceValue('3.14')).toBe(3.14)
+  })
+
+  it('coerces boolean strings', () => {
+    expect(coerceValue('true')).toBe(true)
+    expect(coerceValue('false')).toBe(false)
+  })
+
+  it('coerces null/undefined sentinels', () => {
+    expect(coerceValue('null')).toBe(null)
+    expect(coerceValue('undefined')).toBe(undefined)
+    expect(coerceValue('')).toBe(undefined)
+  })
+
+  it('leaves non-string values alone', () => {
+    expect(coerceValue(42)).toBe(42)
+    expect(coerceValue(null)).toBe(null)
+    expect(coerceValue(undefined)).toBe(undefined)
+  })
+
+  it('does not coerce strings that only partially parse as numbers', () => {
+    // Number('42abc') → NaN; but Number('42 ') → 42, filter via round-trip.
+    expect(coerceValue('42abc')).toBe('42abc')
+    expect(coerceValue('42 ')).toBe('42 ')
+  })
+})
+
+describe('coerceObject', () => {
+  it('coerces one level deep', () => {
+    const obj = { id: '42', active: 'true', nested: { score: '3.14' } }
+    coerceObject(obj)
+    expect(obj).toEqual({ id: 42, active: true, nested: { score: 3.14 } })
+  })
+
+  it('coerces array elements', () => {
+    const obj = { ids: ['1', '2', '3'] }
+    coerceObject(obj)
+    expect(obj.ids).toEqual([1, 2, 3])
+  })
+})
+
+describe('coerceGuard integration', () => {
+  it('works when no input schema is used — resolver sees coerced values', async () => {
+    const s = silgi({ context: () => ({}) })
+    const r = s.router({
+      peek: s.$use(coerceGuard).$resolve(({ input }) => input),
+    })
+
+    const handler = s.handler(r)
+    const res = await handler(
+      new Request('http://localhost/peek', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: '42', flag: 'true' }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 42, flag: true })
+  })
+
+  it('documented caveat: z.number() rejects "42" because validate runs before the wrap', async () => {
+    const s = silgi({ context: () => ({}) })
+    const r = s.router({
+      strict: s
+        .$use(coerceGuard)
+        .$input(z.object({ id: z.number() }))
+        .$resolve(({ input }) => input),
+    })
+
+    const handler = s.handler(r)
+    const res = await handler(
+      new Request('http://localhost/strict', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: '42' }),
+      }),
+    )
+    // Validation fires first; string fails z.number() — coerceGuard never runs.
+    // This test pins that documented behavior so users see a signal if a future
+    // reorder accidentally "fixes" it and breaks the other documented paths.
+    expect(res.status).toBe(400)
+  })
+
+  it('recommended pattern: pair with z.coerce.number() — validate handles coercion', async () => {
+    const s = silgi({ context: () => ({}) })
+    const r = s.router({
+      lenient: s.$input(z.object({ id: z.coerce.number() })).$resolve(({ input }) => input),
+    })
+
+    const handler = s.handler(r)
+    const res = await handler(
+      new Request('http://localhost/lenient', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: '42' }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 42 })
+  })
+})

--- a/test/server/handler.test.ts
+++ b/test/server/handler.test.ts
@@ -130,4 +130,10 @@ describe('handler() — basePath option', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ status: 'ok' })
   })
+
+  it('does not match prefix as a substring — /api2/... returns 404', async () => {
+    // Boundary check: `/api2/health` must not silently route to `/health`.
+    const res = await handle(new Request('http://localhost/api2/health', { method: 'POST' }))
+    expect(res.status).toBe(404)
+  })
 })

--- a/test/server/hooks.test.ts
+++ b/test/server/hooks.test.ts
@@ -174,4 +174,38 @@ describe('lifecycle hooks', () => {
     const body = await res.json()
     expect(body.status).toBe('ok')
   })
+
+  it('throwing hooks are logged but never fail the request', async () => {
+    // Prior impl silently swallowed hook errors via `catch {}` — a
+    // misspelled property or failed `fetch` inside a user hook just
+    // vanished, with no signal that anything was wrong. Now we log.
+    const calls: Array<[string, unknown]> = []
+    const origError = console.error
+    console.error = (...args: unknown[]) => calls.push(['error', args])
+    try {
+      const { handle } = createApp({
+        request: () => {
+          throw new Error('sync hook boom')
+        },
+        response: async () => {
+          throw new Error('async hook boom')
+        },
+      })
+
+      const res = await get(handle, 'health')
+      // Request itself succeeds
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.status).toBe('ok')
+
+      // Wait a tick for the async hook rejection to surface
+      await new Promise((r) => setTimeout(r, 10))
+
+      const messages = calls.map(([, args]) => (args as unknown[]).join(' '))
+      expect(messages.some((m) => m.includes('sync hook boom'))).toBe(true)
+      expect(messages.some((m) => m.includes('async hook boom'))).toBe(true)
+    } finally {
+      console.error = origError
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Twelve correctness fixes uncovered by auditing the codebase after #12. Every one was a real bug — a silent failure, an uncaught exception, a listener leak, or a documentation lie. None touched performance; all added regression tests.

Commits are atomic: one fix, one commit, one test case per fix. Stack on top of #12 or after — they're independent of root wraps.

## Fixes

**Round 1 — the six highest-severity.**

1. \`fix(lazy)\` — rejected imports stayed cached forever; every future \`resolveLazy\` replayed the rejection. A transient hiccup wedged the router permanently.
2. \`fix(adapters)\` — \`pathname.startsWith(prefix)\` matched substrings. \`/api2/health\` silently routed to \`/health\` when prefix was \`/api\`. Both aws-lambda and core/handler affected. Also folds in the wrapHandler init rejection wedge.
3. \`fix(input)\` — Bun swallowed malformed JSON as \`undefined\`; Node/Deno rejected with 400. Same payload reached resolvers differently per runtime. Now unified.
4. \`fix(caller)\` — \`timeout: null\` without a signal passed \`undefined as AbortSignal\`. Any resolver reading \`signal.aborted\` NPE'd.
5. \`fix(retry)\` — \`withRetry\` leaked \`abort\` listeners on long-lived signals (page-level AbortControllers).
6. \`fix(analytics)\` — unguarded \`await request.json()\` on \`/hidden\` endpoint surfaced malformed bodies as uncaught 500s instead of 400s.

**Round 2 — five more bugs surfaced by the follow-up pass.**

7. \`fix(input)\` — \`indexOf('data=')\` matched any key ending in "data" (\`userdata=\`, \`xdata=\`, etc.), silently parsing the wrong value as input. Replaced with a key-boundary scanner.
8. \`fix(handler)\` — hook errors were silently swallowed via \`catch {}\`. User hook bugs (misspelled fields, failed fetches) vanished. Now routed through \`console.error\` with a \`[silgi] hook "<name>" threw:\` prefix.
9. \`fix(url)\` — \`parseUrlPath\` assumed \`//\` protocol separator. Bare-path inputs (test harnesses, prefix-stripping adapters) produced bogus offsets. Added explicit branches for bare paths, paths without authority, and unparseable inputs.
10. \`fix(cache)\` — the ocache bridge discarded \`storage.setItem\` Promises. ocache couldn't await writes, so Redis/S3 failures looked instantaneously successful. Now returns the Promise.
11. \`docs(coerce)\` — the top-level example was false: \`z.number()\` rejects "42" before \`coerceGuard\` runs because input validation runs before the wrap onion. Rewrote the docstring to list three working patterns; added tests that pin the documented behavior.

**Doc fix.**

12. \`docs(map-input)\` — the doc claimed mapInput writes to a \`__mappedInput\` property on ctx. The code has always used the \`RAW_INPUT\` symbol slot.

## Test plan

- [x] 40+ new regression tests across the affected files.
- [x] Full suite: 908 passed / 19 skipped (pre-sweep: 855 / 19).
- [x] Typecheck clean.
- [x] Lint clean (40 preexisting warnings, 0 errors).
- [x] Format clean.

## Severity

| # | File | Severity | Impact |
|---|------|----------|--------|
| 1 | \`src/lazy.ts\` | high | Transient import error → router permanently broken |
| 2 | \`src/adapters/aws-lambda.ts\`, \`src/core/handler.ts\` | high | Cross-route leak on prefix substring + init wedge |
| 3 | \`src/core/input.ts\` (JSON) | high | Malformed body accepted on Bun, rejected elsewhere |
| 4 | \`src/caller.ts\` | medium | NPE in resolvers with \`timeout: null\` |
| 5 | \`src/client/plugins/retry.ts\` | medium | Listener accumulation on long-lived signals |
| 6 | \`src/plugins/analytics/routes.ts\` | medium | 500 instead of 400 for malformed body |
| 7 | \`src/core/input.ts\` (query) | medium | \`?userdata=...\` hijacked as input |
| 8 | \`src/core/handler.ts\` (hooks) | medium | User hook errors silently vanished |
| 9 | \`src/core/url.ts\` | medium | Bare-path input produced bogus routes |
| 10 | \`src/plugins/cache.ts\` | medium | Storage write failures silently succeeded |
| 11 | \`src/plugins/coerce.ts\` | low | Docstring showed non-working example |
| 12 | \`src/map-input.ts\` | low | Docstring referenced non-existent property |

🤖 Generated with [Claude Code](https://claude.com/claude-code)