### PR TITLE
chore(dashboard): re-run oxfmt on drifted files

### DIFF
--- a/dashboard/src/lib/markdown.ts
+++ b/dashboard/src/lib/markdown.ts
@@ -1,5 +1,6 @@
-import type { ErrorEntry, ProcedureCall, RequestEntry, TaskExecution, TraceSpan } from './types'
 import { redactHeader } from './privacy'
+
+import type { ErrorEntry, ProcedureCall, RequestEntry, TaskExecution, TraceSpan } from './types'
 
 function safeJson(value: unknown): string {
   try {

--- a/dashboard/src/lib/privacy.ts
+++ b/dashboard/src/lib/privacy.ts
@@ -1,8 +1,17 @@
 const REDACTED = '[REDACTED]'
-const SENSITIVE_HEADERS = new Set(['authorization', 'cookie', 'set-cookie', 'x-api-key', 'x-auth-token', 'proxy-authorization'])
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'proxy-authorization',
+])
 
 function isLocalHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '0.0.0.0' || hostname.endsWith('.localhost')
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '0.0.0.0' || hostname.endsWith('.localhost')
+  )
 }
 
 export function shouldRedactSensitiveData(): boolean {


### PR DESCRIPTION
## Summary

- `dashboard/src/lib/markdown.ts`: import-order fix (oxfmt group ordering)
- `dashboard/src/lib/privacy.ts`: long array + long conditional wrapped to the project's print width

These two files drifted away from the repo's oxfmt style at some point — likely a manual edit or an IDE auto-format with different settings. `pnpm lint` fails on `main` because of them.

## Why a separate PR

Pure whitespace. No behaviour change, no test impact, nothing to review beyond "does it come back clean under \`pnpm lint\`".

## Test plan

- [x] \`pnpm format\` produces no further diffs
- [x] \`pnpm test\` — 912 passing, 19 skipped (unchanged)
- [x] \`pnpm typecheck\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)