### PR TITLE
fix(schema): surface validator crashes instead of generic 500 (#22)

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -27,7 +27,7 @@
 
 import { SilgiError } from './core/error.ts'
 import { isProcedureDef } from './core/router-utils.ts'
-import { validateSchema } from './core/schema.ts'
+import { SchemaValidatorCrash, validateSchema } from './core/schema.ts'
 
 import type { ProcedureDef, GuardDef, WrapDef, ErrorDef } from './types.ts'
 
@@ -53,6 +53,67 @@ export type CompiledHandler = (
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   return value !== null && typeof value === 'object' && typeof (value as any).then === 'function'
+}
+
+/**
+ * `true` when the runtime is not in production. Used to gate the
+ * dev-only `console.error(...)` for output-validator crashes — in prod
+ * we still surface the cause through `SilgiError.cause`, but we don't
+ * spam the log.
+ */
+const IS_DEV: boolean =
+  typeof process !== 'undefined' && (process as { env?: { NODE_ENV?: string } }).env?.NODE_ENV !== 'production'
+
+/**
+ * Re-throw a `SchemaValidatorCrash` with the right HTTP semantics:
+ *
+ * - **input** validators that crash → `BAD_REQUEST` (the client sent
+ *   something the validator couldn't even evaluate). Cause is preserved
+ *   so server-side logging still has the stack.
+ * - **output** validators that crash → `INTERNAL_SERVER_ERROR` with the
+ *   original throw as `cause`. This is a server bug — the resolver
+ *   produced data the schema can't validate (or the schema itself is
+ *   misconstructed, e.g. zod-v4 `z.record(z.unknown())` without
+ *   `keyType`). In dev we also `console.error` the underlying error so
+ *   the stack actually appears in the dev server log.
+ *
+ * Anything that isn't a `SchemaValidatorCrash` is rethrown unchanged.
+ */
+function rethrowSchemaCrash(error: unknown, kind: 'input' | 'output'): never {
+  if (!(error instanceof SchemaValidatorCrash)) throw error
+  if (kind === 'input') {
+    throw new SilgiError('BAD_REQUEST', {
+      message: 'Input schema validator crashed',
+      cause: error.cause,
+    })
+  }
+  if (IS_DEV) {
+    // Surface the stack in the dev server log — otherwise the only
+    // signal is a generic 500 and the bug is invisible.
+    console.error('[silgi] output schema validator crashed:', error.cause)
+  }
+  throw new SilgiError('INTERNAL_SERVER_ERROR', {
+    message: 'Output schema validator crashed',
+    cause: error.cause,
+  })
+}
+
+/** Run `validateSchema` and rebrand any `SchemaValidatorCrash` for the given kind. */
+function validateOrCrash(
+  schema: import('./core/schema.ts').AnySchema,
+  value: unknown,
+  kind: 'input' | 'output',
+): unknown {
+  let validated: unknown
+  try {
+    validated = validateSchema(schema, value)
+  } catch (e) {
+    rethrowSchemaCrash(e, kind)
+  }
+  if (isThenable(validated)) {
+    return (validated as Promise<unknown>).catch((e: unknown) => rethrowSchemaCrash(e, kind))
+  }
+  return validated
 }
 
 function createFail(errors: ErrorDef): (code: string, data?: unknown) => never {
@@ -218,9 +279,9 @@ function resolveWithOutput(
   })
   if (!outputSchema) return output
   if (isThenable(output)) {
-    return (output as Promise<unknown>).then((o) => validateSchema(outputSchema, o))
+    return (output as Promise<unknown>).then((o) => validateOrCrash(outputSchema, o, 'output'))
   }
-  return validateSchema(outputSchema, output)
+  return validateOrCrash(outputSchema, output, 'output')
 }
 
 /**
@@ -241,7 +302,7 @@ function validateAndResolve(
   signal: AbortSignal,
 ): unknown {
   try {
-    const input = inputSchema ? validateSchema(inputSchema, rawInput ?? {}) : rawInput
+    const input = inputSchema ? validateOrCrash(inputSchema, rawInput ?? {}, 'input') : rawInput
     if (isThenable(input)) {
       return (input as Promise<unknown>).then((resolvedInput) =>
         resolveWithOutput(resolveFn, resolvedInput, ctx, failFn, signal, outputSchema),
@@ -351,7 +412,7 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
 
     let input: unknown
     if (inputSchema) {
-      const validated = validateSchema(inputSchema, rawInput ?? {})
+      const validated = validateOrCrash(inputSchema, rawInput ?? {}, 'input')
       input = isThenable(validated) ? await validated : validated
     } else {
       input = rawInput
@@ -382,7 +443,7 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
 
     const output = await execute()
     if (!outputSchema) return output
-    const validated = validateSchema(outputSchema, output)
+    const validated = validateOrCrash(outputSchema, output, 'output')
     return isThenable(validated) ? await validated : validated
   }
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -56,21 +56,9 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
 }
 
 /**
- * `true` when the runtime is not in production. Used to gate the
- * dev-only `console.error(...)` for output-validator crashes — in prod
- * we still surface the cause through `SilgiError.cause`, but we don't
- * spam the log.
- *
- * Defaults to `true` when `process` is unavailable (Workers, browser,
- * Deno without `--allow-env`). The whole point of the log is to make
- * silent server-side bugs visible — staying loud by default in those
- * runtimes is the safer call. Production deploys that *do* have
- * `process.env.NODE_ENV === 'production'` are still respected.
- *
- * Read once per crash (not at module-load) so tests can mutate
- * `process.env.NODE_ENV` to pin behaviour. The crash path runs at
- * "zero" frequency (only when a schema actually blows up), so a
- * per-call lookup costs nothing in practice.
+ * Defaults to `true` when `process` is unavailable (Workers/browser) so
+ * crashes stay loud by default. Read per-crash so tests can flip
+ * `NODE_ENV` at runtime — the crash path is cold, the cost is moot.
  */
 function isDevEnv(): boolean {
   if (typeof process === 'undefined') return true
@@ -78,53 +66,58 @@ function isDevEnv(): boolean {
 }
 
 /**
- * Re-throw a `SchemaValidatorCrash` with the right HTTP semantics:
- *
- * - **input** validators that crash → `BAD_REQUEST` (the client sent
- *   something the validator couldn't even evaluate). Cause is preserved
- *   so server-side logging still has the stack.
- * - **output** validators that crash → `INTERNAL_SERVER_ERROR` with the
- *   original throw as `cause`. This is a server bug — the resolver
- *   produced data the schema can't validate (or the schema itself is
- *   misconstructed, e.g. zod-v4 `z.record(z.unknown())` without
- *   `keyType`). In dev we also `console.error` the underlying error so
- *   the stack actually appears in the dev server log.
- *
- * Anything that isn't a `SchemaValidatorCrash` is rethrown unchanged.
+ * Validate input. A validator that crashes (e.g. a misconstructed
+ * Zod v4 schema) becomes a `BAD_REQUEST` with the original throw on
+ * `cause` — the client sent something the validator couldn't even
+ * evaluate. Soft `ValidationError` results pass through unchanged.
  */
-function rethrowSchemaCrash(error: unknown, kind: 'input' | 'output'): never {
-  if (!(error instanceof SchemaValidatorCrash)) throw error
-  if (kind === 'input') {
-    throw new SilgiError('BAD_REQUEST', {
-      message: 'Input schema validator crashed',
-      cause: error.cause,
-    })
-  }
-  if (isDevEnv()) {
-    // Surface the stack in the dev server log — otherwise the only
-    // signal is a generic 500 and the bug is invisible.
-    console.error('[silgi] output schema validator crashed:', error.cause)
-  }
-  throw new SilgiError('INTERNAL_SERVER_ERROR', {
-    message: 'Output schema validator crashed',
-    cause: error.cause,
-  })
-}
-
-/** Run `validateSchema` and rebrand any `SchemaValidatorCrash` for the given kind. */
-function validateOrCrash(
-  schema: import('./core/schema.ts').AnySchema,
-  value: unknown,
-  kind: 'input' | 'output',
-): unknown {
+function validateInput(schema: import('./core/schema.ts').AnySchema, value: unknown): unknown {
   let validated: unknown
   try {
     validated = validateSchema(schema, value)
   } catch (e) {
-    rethrowSchemaCrash(e, kind)
+    if (e instanceof SchemaValidatorCrash) {
+      throw new SilgiError('BAD_REQUEST', { message: 'Input schema validator crashed', cause: e.cause })
+    }
+    throw e
   }
   if (isThenable(validated)) {
-    return (validated as Promise<unknown>).catch((e: unknown) => rethrowSchemaCrash(e, kind))
+    return (validated as Promise<unknown>).catch((e: unknown) => {
+      if (e instanceof SchemaValidatorCrash) {
+        throw new SilgiError('BAD_REQUEST', { message: 'Input schema validator crashed', cause: e.cause })
+      }
+      throw e
+    })
+  }
+  return validated
+}
+
+/**
+ * Validate output. A validator that crashes becomes an
+ * `INTERNAL_SERVER_ERROR` (server bug, not user input) with the original
+ * throw on `cause`. In dev the cause is also `console.error`'d so the
+ * stack shows up in the server log — the only signal otherwise is a
+ * generic 500.
+ */
+function validateOutput(schema: import('./core/schema.ts').AnySchema, value: unknown): unknown {
+  let validated: unknown
+  try {
+    validated = validateSchema(schema, value)
+  } catch (e) {
+    if (e instanceof SchemaValidatorCrash) {
+      if (isDevEnv()) console.error('[silgi] output schema validator crashed:', e.cause)
+      throw new SilgiError('INTERNAL_SERVER_ERROR', { message: 'Output schema validator crashed', cause: e.cause })
+    }
+    throw e
+  }
+  if (isThenable(validated)) {
+    return (validated as Promise<unknown>).catch((e: unknown) => {
+      if (e instanceof SchemaValidatorCrash) {
+        if (isDevEnv()) console.error('[silgi] output schema validator crashed:', e.cause)
+        throw new SilgiError('INTERNAL_SERVER_ERROR', { message: 'Output schema validator crashed', cause: e.cause })
+      }
+      throw e
+    })
   }
   return validated
 }
@@ -269,7 +262,6 @@ function selectGuardRunner(
 
 // ── Resolve + output validation helper ──────────────
 
-/** Call resolve, then validate output (sync-first, async fallback) */
 /**
  * Call the resolver, then validate the output. Stays sync when the
  * resolver is sync and there is no output schema; switches to
@@ -292,9 +284,9 @@ function resolveWithOutput(
   })
   if (!outputSchema) return output
   if (isThenable(output)) {
-    return (output as Promise<unknown>).then((o) => validateOrCrash(outputSchema, o, 'output'))
+    return (output as Promise<unknown>).then((o) => validateOutput(outputSchema, o))
   }
-  return validateOrCrash(outputSchema, output, 'output')
+  return validateOutput(outputSchema, output)
 }
 
 /**
@@ -315,7 +307,7 @@ function validateAndResolve(
   signal: AbortSignal,
 ): unknown {
   try {
-    const input = inputSchema ? validateOrCrash(inputSchema, rawInput ?? {}, 'input') : rawInput
+    const input = inputSchema ? validateInput(inputSchema, rawInput ?? {}) : rawInput
     if (isThenable(input)) {
       return (input as Promise<unknown>).then((resolvedInput) =>
         resolveWithOutput(resolveFn, resolvedInput, ctx, failFn, signal, outputSchema),
@@ -425,7 +417,7 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
 
     let input: unknown
     if (inputSchema) {
-      const validated = validateOrCrash(inputSchema, rawInput ?? {}, 'input')
+      const validated = validateInput(inputSchema, rawInput ?? {})
       input = isThenable(validated) ? await validated : validated
     } else {
       input = rawInput
@@ -456,7 +448,7 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
 
     const output = await execute()
     if (!outputSchema) return output
-    const validated = validateOrCrash(outputSchema, output, 'output')
+    const validated = validateOutput(outputSchema, output)
     return isThenable(validated) ? await validated : validated
   }
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -60,9 +60,22 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
  * dev-only `console.error(...)` for output-validator crashes — in prod
  * we still surface the cause through `SilgiError.cause`, but we don't
  * spam the log.
+ *
+ * Defaults to `true` when `process` is unavailable (Workers, browser,
+ * Deno without `--allow-env`). The whole point of the log is to make
+ * silent server-side bugs visible — staying loud by default in those
+ * runtimes is the safer call. Production deploys that *do* have
+ * `process.env.NODE_ENV === 'production'` are still respected.
+ *
+ * Read once per crash (not at module-load) so tests can mutate
+ * `process.env.NODE_ENV` to pin behaviour. The crash path runs at
+ * "zero" frequency (only when a schema actually blows up), so a
+ * per-call lookup costs nothing in practice.
  */
-const IS_DEV: boolean =
-  typeof process !== 'undefined' && (process as { env?: { NODE_ENV?: string } }).env?.NODE_ENV !== 'production'
+function isDevEnv(): boolean {
+  if (typeof process === 'undefined') return true
+  return (process as { env?: { NODE_ENV?: string } }).env?.NODE_ENV !== 'production'
+}
 
 /**
  * Re-throw a `SchemaValidatorCrash` with the right HTTP semantics:
@@ -87,7 +100,7 @@ function rethrowSchemaCrash(error: unknown, kind: 'input' | 'output'): never {
       cause: error.cause,
     })
   }
-  if (IS_DEV) {
+  if (isDevEnv()) {
     // Surface the stack in the dev server log — otherwise the only
     // signal is a generic 500 and the bug is invisible.
     console.error('[silgi] output schema validator crashed:', error.cause)

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -27,6 +27,15 @@ export class ValidationError extends Error {
  * Distinct from `ValidationError` (which means the *value* was bad)
  * because the failure is a server-side schema bug, not user input.
  * `cause` holds the original throw so dev tooling can surface the stack.
+ *
+ * **Where you'll see this.** Only on direct `validateSchema()` calls.
+ * The compiled procedure pipeline catches `SchemaValidatorCrash`
+ * internally and rebrands it as a `SilgiError` (`BAD_REQUEST` for input
+ * validators, `INTERNAL_SERVER_ERROR` for output validators) with the
+ * *original* throw — not the `SchemaValidatorCrash` wrapper — preserved
+ * on `SilgiError.cause`. So `instanceof SchemaValidatorCrash` will not
+ * match anything thrown from a procedure handler; inspect
+ * `SilgiError.cause` instead.
  */
 export class SchemaValidatorCrash extends Error {
   constructor(options: { message?: string; cause: unknown }) {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -20,22 +20,11 @@ export class ValidationError extends Error {
 }
 
 /**
- * Thrown when a Standard Schema validator itself crashes — e.g. a
- * misconstructed Zod v4 schema like `z.record(z.unknown())` (missing
- * `keyType`) that builds silently but throws inside `.validate()`.
- *
- * Distinct from `ValidationError` (which means the *value* was bad)
- * because the failure is a server-side schema bug, not user input.
- * `cause` holds the original throw so dev tooling can surface the stack.
- *
- * **Where you'll see this.** Only on direct `validateSchema()` calls.
- * The compiled procedure pipeline catches `SchemaValidatorCrash`
- * internally and rebrands it as a `SilgiError` (`BAD_REQUEST` for input
- * validators, `INTERNAL_SERVER_ERROR` for output validators) with the
- * *original* throw — not the `SchemaValidatorCrash` wrapper — preserved
- * on `SilgiError.cause`. So `instanceof SchemaValidatorCrash` will not
- * match anything thrown from a procedure handler; inspect
- * `SilgiError.cause` instead.
+ * Thrown when a Standard Schema validator itself crashes (e.g. a
+ * misconstructed Zod v4 schema). Distinct from `ValidationError` —
+ * the *schema* is broken, not the value. `cause` holds the original
+ * throw. Only observable on direct `validateSchema()` calls; the
+ * pipeline rebrands these as `SilgiError` with `cause` preserved.
  */
 export class SchemaValidatorCrash extends Error {
   constructor(options: { message?: string; cause: unknown }) {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -19,9 +19,31 @@ export class ValidationError extends Error {
   }
 }
 
+/**
+ * Thrown when a Standard Schema validator itself crashes — e.g. a
+ * misconstructed Zod v4 schema like `z.record(z.unknown())` (missing
+ * `keyType`) that builds silently but throws inside `.validate()`.
+ *
+ * Distinct from `ValidationError` (which means the *value* was bad)
+ * because the failure is a server-side schema bug, not user input.
+ * `cause` holds the original throw so dev tooling can surface the stack.
+ */
+export class SchemaValidatorCrash extends Error {
+  constructor(options: { message?: string; cause: unknown }) {
+    super(options.message ?? 'Schema validator crashed', { cause: options.cause })
+    this.name = 'SchemaValidatorCrash'
+  }
+}
+
 /** Sync fast-path: Zod 4 validate() returns sync result — avoid Promise allocation */
 export function validateSchema(schema: AnySchema, value: unknown): unknown {
-  const result = schema['~standard'].validate(value)
+  let result: ReturnType<AnySchema['~standard']['validate']>
+  try {
+    result = schema['~standard'].validate(value)
+  } catch (e) {
+    // Validator threw synchronously — schema construction bug, not bad input.
+    throw new SchemaValidatorCrash({ cause: e })
+  }
   // Sync result (Zod 4, ArkType, Silgi type()) — no Promise overhead
   if (typeof (result as any)?.then !== 'function') {
     if ('issues' in (result as any) && (result as any).issues) {
@@ -29,13 +51,19 @@ export function validateSchema(schema: AnySchema, value: unknown): unknown {
     }
     return (result as { value: unknown }).value
   }
-  // Async fallback (Valibot or custom async schemas)
-  return (result as Promise<any>).then((r: any) => {
-    if ('issues' in r && r.issues) {
-      throw new ValidationError({ issues: r.issues })
-    }
-    return r.value
-  })
+  // Async fallback (Valibot or custom async schemas) — promise reject is
+  // also a validator crash, not a soft validation failure.
+  return (result as Promise<any>).then(
+    (r: any) => {
+      if ('issues' in r && r.issues) {
+        throw new ValidationError({ issues: r.issues })
+      }
+      return r.value
+    },
+    (e: unknown) => {
+      throw new SchemaValidatorCrash({ cause: e })
+    },
+  )
 }
 
 export function type<TInput, TOutput = TInput>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export { SilgiError, isSilgiError, isDefinedError, toSilgiError } from './core/e
 export type { SilgiErrorCode, SilgiErrorOptions, SilgiErrorJSON } from './core/error.ts'
 
 // ── Schema ──────────────────────────────────────────
-export { type, validateSchema, ValidationError } from './core/schema.ts'
+export { type, validateSchema, ValidationError, SchemaValidatorCrash } from './core/schema.ts'
 export type { Schema, AnySchema, InferSchemaInput, InferSchemaOutput } from './core/schema.ts'
 
 // ── Schema Converters ───────────────────────────────

--- a/test/core/schema-validator-crash.test.ts
+++ b/test/core/schema-validator-crash.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { compileProcedure } from '#src/compile.ts'
+import { SilgiError } from '#src/core/error.ts'
+import { SchemaValidatorCrash, validateSchema, type AnySchema } from '#src/core/schema.ts'
+import { silgi } from '#src/silgi.ts'
+
+const k = silgi({ context: () => ({}) })
+
+function syncCrashSchema(message = 'boom'): AnySchema {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'test',
+      validate() {
+        throw new TypeError(message)
+      },
+    },
+  } as AnySchema
+}
+
+function asyncCrashSchema(message = 'async-boom'): AnySchema {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'test',
+      validate() {
+        return Promise.reject(new TypeError(message))
+      },
+    },
+  } as AnySchema
+}
+
+function passthroughSchema(): AnySchema {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'test',
+      validate(value: unknown) {
+        return { value }
+      },
+    },
+  } as AnySchema
+}
+
+// === validateSchema raw behaviour ===
+
+describe('validateSchema — validator crash handling', () => {
+  it('wraps a synchronous validator throw as SchemaValidatorCrash', () => {
+    expect(() => validateSchema(syncCrashSchema('inner'), {})).toThrowError(SchemaValidatorCrash)
+    try {
+      validateSchema(syncCrashSchema('inner'), {})
+    } catch (e) {
+      expect(e).toBeInstanceOf(SchemaValidatorCrash)
+      expect((e as SchemaValidatorCrash).cause).toBeInstanceOf(TypeError)
+      expect(((e as SchemaValidatorCrash).cause as Error).message).toBe('inner')
+    }
+  })
+
+  it('wraps an async validator rejection as SchemaValidatorCrash', async () => {
+    const result = validateSchema(asyncCrashSchema('async-inner'), {})
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result as Promise<unknown>).rejects.toBeInstanceOf(SchemaValidatorCrash)
+    try {
+      await (result as Promise<unknown>)
+    } catch (e) {
+      expect((e as SchemaValidatorCrash).cause).toBeInstanceOf(TypeError)
+      expect(((e as SchemaValidatorCrash).cause as Error).message).toBe('async-inner')
+    }
+  })
+})
+
+// === compileProcedure: input vs output classification ===
+
+describe('compileProcedure — schema crash classification', () => {
+  it('classifies an input validator crash as BAD_REQUEST', async () => {
+    const proc = k.$input(syncCrashSchema()).$resolve(() => 'unreachable')
+    const handler = compileProcedure(proc)
+    await expect(handler({}, { any: 'thing' }, AbortSignal.timeout(1000))).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      status: 400,
+    })
+  })
+
+  it('preserves the original throw as cause on input crashes', async () => {
+    const proc = k.$input(syncCrashSchema('input-stack')).$resolve(() => 'unreachable')
+    const handler = compileProcedure(proc)
+    try {
+      await handler({}, {}, AbortSignal.timeout(1000))
+    } catch (e) {
+      expect(e).toBeInstanceOf(SilgiError)
+      const cause = (e as SilgiError).cause as Error
+      expect(cause).toBeInstanceOf(TypeError)
+      expect(cause.message).toBe('input-stack')
+    }
+  })
+
+  it('classifies a sync output validator crash as INTERNAL_SERVER_ERROR', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const proc = k.$output(syncCrashSchema('out-stack')).$resolve(() => ({ ok: true }))
+      const handler = compileProcedure(proc)
+      await expect(handler({}, undefined, AbortSignal.timeout(1000))).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        status: 500,
+      })
+      // dev-mode log surfaced the underlying TypeError
+      expect(errorSpy).toHaveBeenCalled()
+      const args = errorSpy.mock.calls[0]!
+      expect(args[1]).toBeInstanceOf(TypeError)
+      expect((args[1] as Error).message).toBe('out-stack')
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('classifies an async output validator crash as INTERNAL_SERVER_ERROR', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const proc = k.$output(asyncCrashSchema('async-out')).$resolve(() => ({ ok: true }))
+      const handler = compileProcedure(proc)
+      await expect(handler({}, undefined, AbortSignal.timeout(1000))).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        status: 500,
+      })
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('does not affect happy-path output validation', async () => {
+    const proc = k.$output(passthroughSchema()).$resolve(() => ({ ok: true }))
+    const handler = compileProcedure(proc)
+    const result = await handler({}, undefined, AbortSignal.timeout(1000))
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/test/core/schema-validator-crash.test.ts
+++ b/test/core/schema-validator-crash.test.ts
@@ -137,4 +137,48 @@ describe('compileProcedure — schema crash classification', () => {
     const result = await handler({}, undefined, AbortSignal.timeout(1000))
     expect(result).toEqual({ ok: true })
   })
+
+  it('suppresses dev-mode log when NODE_ENV=production but still 500s with cause', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const prevEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      const proc = k.$output(syncCrashSchema('prod-out')).$resolve(() => ({ ok: true }))
+      const handler = compileProcedure(proc)
+      try {
+        await handler({}, undefined, AbortSignal.timeout(1000))
+        throw new Error('expected rejection')
+      } catch (e) {
+        expect(e).toBeInstanceOf(SilgiError)
+        expect((e as SilgiError).code).toBe('INTERNAL_SERVER_ERROR')
+        expect((e as SilgiError).cause).toBeInstanceOf(TypeError)
+        expect(((e as SilgiError).cause as Error).message).toBe('prod-out')
+      }
+      expect(errorSpy).not.toHaveBeenCalled()
+    } finally {
+      if (prevEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevEnv
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('logs dev-mode output crash even when `process` is unavailable (Workers/browser)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const realProcess = globalThis.process
+    // Simulate a runtime where `process` is not defined at all.
+    delete (globalThis as { process?: unknown }).process
+    try {
+      const proc = k.$output(syncCrashSchema('no-process')).$resolve(() => ({ ok: true }))
+      const handler = compileProcedure(proc)
+      await expect(handler({}, undefined, AbortSignal.timeout(1000))).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        status: 500,
+      })
+      // Without `process`, we default to dev-on so the crash is visible.
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      ;(globalThis as { process?: unknown }).process = realProcess
+      errorSpy.mockRestore()
+    }
+  })
 })

--- a/test/core/schema-validator-crash.test.ts
+++ b/test/core/schema-validator-crash.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { compileProcedure } from '#src/compile.ts'
 import { SilgiError } from '#src/core/error.ts'
-import { SchemaValidatorCrash, validateSchema, type AnySchema } from '#src/core/schema.ts'
+import { SchemaValidatorCrash, validateSchema } from '#src/core/schema.ts'
 import { silgi } from '#src/silgi.ts'
+
+import type { AnySchema } from '#src/core/schema.ts'
 
 const k = silgi({ context: () => ({}) })
 


### PR DESCRIPTION
## Summary

Fixes #22.

A misconstructed Zod v4 schema like `z.record(z.unknown())` (missing the required `keyType` argument) builds silently and throws a `TypeError` only when `.validate()` runs. Silgi's `validateSchema` only handled the soft-fail `result.issues` case, so the raw throw bubbled into `toSilgiError` and was redacted to a generic `INTERNAL_SERVER_ERROR` — no detail to the client and no stack in the dev log either.

This change splits "validator itself crashed" from "value was bad" and reclassifies the crash by source.

## Changes

- **`src/core/schema.ts`** — new `SchemaValidatorCrash` error class. `validateSchema` now wraps both the sync `.validate()` call and the async result in try/catch / `.then(_, onReject)`, so any throw becomes a `SchemaValidatorCrash` with the original error as `cause`.
- **`src/compile.ts`** — new `validateOrCrash(schema, value, kind)` helper. Input validator crashes → `BAD_REQUEST` (the client sent something the validator couldn't even evaluate). Output validator crashes → `INTERNAL_SERVER_ERROR` with the original throw preserved as `cause`, plus a dev-mode `console.error` so the stack actually shows up in the dev server log. All three call sites (sync `validateAndResolve`, sync output in `resolveWithOutput`, async output, and the inner-handler input path) routed through the helper.
- **`src/index.ts`** — re-export `SchemaValidatorCrash` for downstream consumers (e.g. custom adapters).
- **`test/core/schema-validator-crash.test.ts`** — covers sync throw, async reject, input-vs-output classification, dev-mode log, and the happy path.

## Behaviour matrix

| Where the crash happens | Before | After |
|---|---|---|
| Input schema, sync throw | 500 INTERNAL_SERVER_ERROR, no log | 400 BAD_REQUEST, cause preserved |
| Output schema, sync throw | 500 INTERNAL_SERVER_ERROR, no log | 500 INTERNAL_SERVER_ERROR, cause preserved + `console.error` in dev |
| Output schema, async reject | unhandled rejection / 500 with no signal | 500 INTERNAL_SERVER_ERROR, cause preserved + `console.error` in dev |

Production behaviour is unchanged for clients (still a generic 500 message, no internal details leaked) — the cause is only logged in dev.

## Test plan

- [x] `pnpm test` — 919 pass / 19 pre-existing skipped, no regressions
- [x] `pnpm typecheck` — clean
- [x] New unit tests cover sync throw, async reject, input/output classification, dev-mode logging, happy path
- [ ] Reviewer confirms behaviour with the original Zod v4 `z.record(z.unknown())` repro from #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)