### PR TITLE
fix(client): decode SSE responses in fetch + ofetch adapters (#24)

### DIFF
--- a/src/client/adapters/fetch/index.ts
+++ b/src/client/adapters/fetch/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { SilgiError, isSilgiErrorJSON, fromSilgiErrorJSON, isErrorStatus } from '../../../core/error.ts'
+import { eventStreamToIterator } from '../../../core/sse.ts'
 import { stringifyJSON, parseEmptyableJSON } from '../../../core/utils.ts'
 
 import type { ClientLink, ClientContext, ClientOptions } from '../../types.ts'
@@ -51,6 +52,14 @@ export class RPCLink<TClientContext extends ClientContext = ClientContext> imple
     })
 
     const contentType = response.headers.get('content-type') ?? ''
+
+    // Subscription response — server emitted an async iterator as SSE.
+    // Hand back an iterator that decodes frames lazily; the consumer
+    // drives consumption via `for await` / `consumeIterator`.
+    if (contentType.includes('text/event-stream') && response.body) {
+      return eventStreamToIterator(response.body)
+    }
+
     let responseBody: unknown
     if (contentType.includes('msgpack')) {
       const { decode } = await import('../../../codec/msgpack.ts')

--- a/src/client/adapters/ofetch/index.ts
+++ b/src/client/adapters/ofetch/index.ts
@@ -9,6 +9,7 @@ import { ofetch, FetchError } from 'ofetch'
 
 import { encode as msgpackEncode, decode as msgpackDecode, MSGPACK_CONTENT_TYPE } from '../../../codec/msgpack.ts'
 import { SilgiError, isSilgiErrorJSON, fromSilgiErrorJSON } from '../../../core/error.ts'
+import { eventStreamToIterator } from '../../../core/sse.ts'
 
 import type { ClientLink, ClientContext, ClientOptions } from '../../types.ts'
 import type { FetchOptions, FetchContext } from 'ofetch'
@@ -109,7 +110,11 @@ export function createLink<TClientContext extends ClientContext = ClientContext>
       }
 
       try {
-        const data = await ofetch(url, {
+        // `responseType: 'stream'` keeps ofetch from consuming the body
+        // so we can branch on `content-type`: subscriptions need the
+        // raw stream for SSE decoding, while query/mutation responses
+        // get decoded here per protocol.
+        const response = await ofetch.raw<ReadableStream<Uint8Array>, 'stream'>(url, {
           method: 'POST',
           headers,
           body,
@@ -122,32 +127,39 @@ export function createLink<TClientContext extends ClientContext = ClientContext>
           onResponse: options.onResponse,
           onRequestError: options.onRequestError,
           onResponseError: options.onResponseError,
-          // Response handling per protocol
-          ...(resolvedProtocol === 'messagepack'
-            ? { responseType: 'arrayBuffer' as const }
-            : resolvedProtocol === 'devalue'
-              ? { responseType: 'text' as const }
-              : {
-                  parseResponse(text: string) {
-                    if (!text) return undefined
-                    try {
-                      return JSON.parse(text)
-                    } catch {
-                      return text
-                    }
-                  },
-                }),
+          responseType: 'stream',
         })
 
-        // Decode response
+        // Subscription response — server emitted an async iterator as SSE.
+        const responseContentType = response.headers.get('content-type') ?? ''
+        if (responseContentType.includes('text/event-stream') && response.body) {
+          return eventStreamToIterator(response.body)
+        }
+
+        // Query/mutation — drain the stream and decode per protocol.
         let decoded: unknown
         if (resolvedProtocol === 'messagepack') {
-          decoded = msgpackDecode(new Uint8Array(data as ArrayBuffer))
+          const buf = new Uint8Array(await new Response(response.body).arrayBuffer())
+          decoded = buf.length > 0 ? msgpackDecode(buf) : undefined
         } else if (resolvedProtocol === 'devalue') {
-          const { decode: devalueDecode } = await import('../../../codec/devalue.ts')
-          decoded = data ? devalueDecode(data as string) : undefined
+          const text = await new Response(response.body).text()
+          if (text) {
+            const { decode: devalueDecode } = await import('../../../codec/devalue.ts')
+            decoded = devalueDecode(text)
+          } else {
+            decoded = undefined
+          }
         } else {
-          decoded = data
+          const text = await new Response(response.body).text()
+          if (!text) {
+            decoded = undefined
+          } else {
+            try {
+              decoded = JSON.parse(text)
+            } catch {
+              decoded = text
+            }
+          }
         }
 
         if (isSilgiErrorJSON(decoded)) {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -17,10 +17,15 @@ export type Client<TClientContext extends ClientContext, TInput, TOutput, _TErro
   ...args: ClientRest<TClientContext, TInput>
 ) => Promise<TOutput>
 
-/** A subscription client — returns async iterator */
+/**
+ * A subscription client — resolves to an async iterator. The Promise
+ * boundary is the network round-trip (open the SSE/WS connection, see
+ * the response headers); the resolved iterator yields each event until
+ * the stream ends.
+ */
 export type SubscriptionClient<TClientContext extends ClientContext, TInput, TOutput> = (
   ...args: ClientRest<TClientContext, TInput>
-) => AsyncIterableIterator<TOutput>
+) => Promise<AsyncIterableIterator<TOutput>>
 
 /** Determine argument shape based on input and context optionality */
 export type ClientRest<TClientContext extends ClientContext, TInput> = undefined extends TInput

--- a/test/client/sse-consume.test.ts
+++ b/test/client/sse-consume.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Client-side SSE decoding — covers fetch + ofetch adapters.
+ *
+ * Pins the contract from issue #24: the typed client returns a Promise
+ * that resolves to an `AsyncIterableIterator`, NOT a Promise<string>.
+ * The iterator yields each frame parsed back into the declared output
+ * shape, so `consumeIterator` works end-to-end.
+ */
+
+import { createServer } from 'node:http'
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { z } from 'zod'
+
+import { RPCLink } from '#src/client/adapters/fetch/index.ts'
+import { createLink as createOfetchLink } from '#src/client/adapters/ofetch/index.ts'
+import { createClient } from '#src/client/client.ts'
+import { consumeIterator } from '#src/client/consume.ts'
+import { silgi } from '#src/silgi.ts'
+
+import type { InferClient } from '#src/types.ts'
+import type { Server } from 'node:http'
+
+const k = silgi({ context: () => ({}) })
+
+const appRouter = k.router({
+  countdown: k
+    .subscription()
+    .$input(z.object({ from: z.number() }))
+    .$resolve(async function* ({ input }) {
+      for (let i = input.from; i > 0; i--) yield { count: i }
+    }),
+})
+
+type AppRouter = typeof appRouter
+const handle = k.handler(appRouter)
+
+// ── shared loopback HTTP server (streams the response body) ─
+
+let server: Server
+let baseUrl: string
+
+beforeAll(async () => {
+  server = createServer(async (req, res) => {
+    const url = `http://localhost${req.url}`
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value) headers.set(key, Array.isArray(value) ? value[0]! : value)
+    }
+    let body: string | undefined
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      body = await new Promise<string>((resolve) => {
+        let data = ''
+        req.on('data', (chunk: Buffer) => {
+          data += chunk
+        })
+        req.on('end', () => resolve(data))
+      })
+    }
+    const fetchReq = new Request(url, { method: req.method, headers, body: body || undefined })
+    const fetchRes = await handle(fetchReq)
+
+    // Stream the response body so SSE frames flow through to the
+    // client incrementally — `await fetchRes.text()` would defeat the
+    // whole point of an event-stream test.
+    res.writeHead(fetchRes.status, Object.fromEntries(fetchRes.headers))
+    if (fetchRes.body) {
+      const reader = fetchRes.body.getReader()
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        res.write(value)
+      }
+    }
+    res.end()
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number }
+      baseUrl = `http://127.0.0.1:${addr.port}`
+      resolve()
+    })
+  })
+})
+
+afterAll(() => {
+  server?.close()
+})
+
+describe('fetch adapter — SSE subscription', () => {
+  it('resolves the call to an iterator that yields each event', async () => {
+    const link = new RPCLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const iterator = await client.countdown({ from: 3 })
+    expect(typeof iterator?.next).toBe('function')
+
+    const events: { count: number }[] = []
+    await consumeIterator(iterator, { onEvent: (e) => void events.push(e) })
+
+    expect(events).toEqual([{ count: 3 }, { count: 2 }, { count: 1 }])
+  })
+})
+
+describe('ofetch adapter — SSE subscription', () => {
+  it('resolves the call to an iterator that yields each event', async () => {
+    const link = createOfetchLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const iterator = await client.countdown({ from: 3 })
+    expect(typeof iterator?.next).toBe('function')
+
+    const events: { count: number }[] = []
+    await consumeIterator(iterator, { onEvent: (e) => void events.push(e) })
+
+    expect(events).toEqual([{ count: 3 }, { count: 2 }, { count: 1 }])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #24.

`subscription` procedures emit `text/event-stream` server-side, but the HTTP client adapters didn't branch on the content type — `ofetch` ran the body through its JSON parser and `fetch` always called `response.text()`. The result: `client.api.myStream(...)` resolved to a string (or a 400) instead of an `AsyncIterableIterator`, and `consumeIterator(iter)` threw `iterator.next is not a function`.

## What changed

- **`client/types.ts`** — `SubscriptionClient` now returns `Promise<AsyncIterableIterator<TOutput>>`. The websocket adapter has always returned a Promise that resolves to an iterator; the type was lying about it. Callers write `const iter = await client.api.stream(...)`.
- **`client/adapters/fetch/index.ts`** — branch on `Content-Type: text/event-stream` before any other decoding. SSE responses go straight to `eventStreamToIterator(response.body)`.
- **`client/adapters/ofetch/index.ts`** — switch to `ofetch.raw` + `responseType: 'stream'` so ofetch's parser never touches the body. Same SSE branch, then drain-and-decode for query/mutation paths (preserves `messagepack`/`devalue`/`json` protocol selection).
- **`test/client/sse-consume.test.ts`** — new E2E test. A real loopback HTTP server pipes the streaming response back through each adapter; `consumeIterator` walks the iterator and asserts each event decodes into the declared output shape.

## Behaviour matrix

| Adapter | Before | After |
|---|---|---|
| `fetch` (subscription) | TypeError / 400 from `response.text()` JSON parse | iterator yielding decoded events |
| `ofetch` (subscription) | TypeError / 400 from ofetch parser | iterator yielding decoded events |
| `fetch` / `ofetch` (query/mutation) | unchanged | unchanged |
| `websocket` | already correct | unchanged |

## Breaking change

`SubscriptionClient`'s return type changed from `AsyncIterableIterator<TOutput>` to `Promise<AsyncIterableIterator<TOutput>>`. Existing TypeScript callers will see a compile error — fix is one keyword:

```diff
- const iter = client.api.myStream(...)
+ const iter = await client.api.myStream(...)
```

The runtime was already a Promise (because every `ClientLink.call` is async). The old type was unsound — the runtime didn't change, just the type that describes it.

## Test plan

- [x] `pnpm test` — 923 pass / 19 pre-existing skipped, no regressions
- [x] `pnpm typecheck` — clean
- [x] New E2E test exercises both fetch + ofetch adapters end-to-end
- [ ] Reviewer confirms the websocket adapter's existing iterator behaviour is unchanged (no code touched, but worth a sanity check)

## Out of scope (worth noting)

While testing I noticed `subscription().$input(...).$output(...)` appears to apply the *output* schema as if it were an input schema — adding `$output(z.object({ count: z.number() }))` makes the server reject `{ from: 3 }` with `BAD_REQUEST` because it validates the input value against the output shape. This is a separate, pre-existing bug — the test sidesteps it by using `$input` only. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)