### PR TITLE
fix(compile): validate each yielded item on subscription $output (#26)

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -122,6 +122,23 @@ function validateOutput(schema: import('./core/schema.ts').AnySchema, value: unk
   return validated
 }
 
+/**
+ * Wrap a subscription's iterator so each yielded item runs through
+ * `validateOutput`. The pre-#26 path validated the iterator object
+ * itself, which always 400'd because schemas can't find their declared
+ * keys on an iterator. A schema crash mid-stream propagates as a thrown
+ * error that the SSE encoder turns into an `error` event.
+ */
+async function* validateIteratorOutput(
+  iterator: AsyncIterableIterator<unknown>,
+  schema: import('./core/schema.ts').AnySchema,
+): AsyncIterableIterator<unknown> {
+  for await (const item of iterator) {
+    const validated = validateOutput(schema, item)
+    yield isThenable(validated) ? await validated : validated
+  }
+}
+
 function createFail(errors: ErrorDef): (code: string, data?: unknown) => never {
   return (code: string, data?: unknown): never => {
     const def = errors[code]
@@ -376,6 +393,7 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
   const inputSchema = procedure.input
   const outputSchema = procedure.output
   const resolveFn = procedure.resolve
+  const isSubscription = procedure.type === 'subscription'
 
   // Merge guard errors into procedure errors (runtime)
   let mergedErrors = procedure.errors
@@ -448,6 +466,12 @@ export function compileProcedure(procedure: ProcedureDef, rootWraps?: readonly W
 
     const output = await execute()
     if (!outputSchema) return output
+    // Subscriptions return an async iterator — validate each yielded
+    // item, not the iterator object itself (the latter always failed
+    // because schemas can't find their declared keys on an iterator).
+    if (isSubscription && output && typeof output === 'object' && Symbol.asyncIterator in output) {
+      return validateIteratorOutput(output as AsyncIterableIterator<unknown>, outputSchema)
+    }
     const validated = validateOutput(outputSchema, output)
     return isThenable(validated) ? await validated : validated
   }

--- a/test/server/subscription.test.ts
+++ b/test/server/subscription.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
 
 import { silgi } from '#src/silgi.ts'
 
@@ -12,9 +13,39 @@ const router = k.router({
   countdown: k.subscription(async function* () {
     for (let i = 3; i > 0; i--) yield { count: i }
   }),
+
+  // Subscription with $output — every yielded item must be validated.
+  withOutput: k
+    .subscription()
+    .$input(z.object({ from: z.number() }))
+    .$output(z.object({ count: z.number() }))
+    .$resolve(async function* ({ input }) {
+      for (let i = input.from; i > 0; i--) yield { count: i }
+    }),
+
+  // Subscription whose resolver yields a value the output schema rejects.
+  invalidYield: k
+    .subscription()
+    .$output(z.object({ count: z.number() }))
+    .$resolve(async function* () {
+      yield { count: 1 }
+      yield { wrong: 'shape' } as unknown as { count: number }
+    }),
 })
 
 const handle = k.handler(router)
+
+async function readBody(res: Response): Promise<string> {
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let all = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    all += decoder.decode(value, { stream: true })
+  }
+  return all
+}
 
 describe('v2 subscription (SSE)', () => {
   it('returns text/event-stream content type', async () => {
@@ -54,5 +85,46 @@ describe('v2 subscription (SSE)', () => {
     expect(values).toContainEqual({ count: 3 })
     expect(values).toContainEqual({ count: 2 })
     expect(values).toContainEqual({ count: 1 })
+  })
+
+  // Regression for #26 — output schema used to be applied to the
+  // iterator object instead of each yielded item, so any subscription
+  // with `$output` 400'd at request time.
+  it('validates each yielded item when $output is set', async () => {
+    const res = await handle(
+      new Request('http://localhost/withOutput', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ from: 3 }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+
+    const body = await readBody(res)
+    const values = body
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.replace('data: ', '').trim())
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { count: number })
+
+    expect(values).toEqual([{ count: 3 }, { count: 2 }, { count: 1 }])
+  })
+
+  // When a yielded value fails the schema, the stream surfaces the
+  // crash as an SSE `error` event after any frames that did pass.
+  it('emits an error event mid-stream when a yield fails the output schema', async () => {
+    const res = await handle(
+      new Request('http://localhost/invalidYield', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await readBody(res)
+    expect(body).toContain('data: {"count":1}')
+    expect(body).toContain('event: error')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #26.

Subscription resolvers return an `AsyncIterableIterator`, but the output-validation step in `compileProcedure` ran the schema against the iterator *object* itself. Schemas couldn't find their declared keys on an iterator, so every subscription with `\$output` 400'd at request time with a `Validation failed` body that pointed at the output shape's fields as if the *client* had sent them.

I noticed this while testing #25 — the SSE consume test had to drop `\$output` from its fixture to even get a 200 response.

## What changed

- **`src/compile.ts`** — when a procedure is a subscription and has an output schema, wrap the returned iterator with `validateIteratorOutput`, which runs `validateOutput` on each yield. Query/mutation paths are unchanged.
- **`test/server/subscription.test.ts`** — two regressions for #26:
  1. Happy path — `subscription + \$input + \$output` streams all yields back through the validator.
  2. Mid-stream failure — a yield that fails the schema produces an SSE `error` event after any valid frames.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| `subscription` + `\$output` (valid yields) | ❌ 400 BAD_REQUEST | ✅ 200, each frame validated |
| `subscription` + `\$output` (one bad yield mid-stream) | ❌ 400 BAD_REQUEST before any frame | ✅ valid frames stream, then SSE `error` event |
| `subscription` without `\$output` | ✅ unchanged | ✅ unchanged |
| `query` / `mutation` + `\$output` | ✅ unchanged | ✅ unchanged |

## Test plan

- [x] `pnpm test` — 925 pass / 19 pre-existing skipped, 2 new tests for #26
- [x] `pnpm typecheck` — clean
- [x] Format check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)