### PR TITLE
feat(client): add misina-based RPC link alongside ofetch

### DIFF
--- a/docs/content/docs/(core)/client.mdx
+++ b/docs/content/docs/(core)/client.mdx
@@ -18,7 +18,10 @@ Setting up the client takes two steps: create a **link** (the transport layer) a
 
 ### Create a link
 
-A link tells the client _how_ to send requests to the server. The built-in link uses [ofetch](https://github.com/unjs/ofetch) for retries, timeouts, and JSON parsing:
+A link tells the client _how_ to send requests to the server. Silgi ships two HTTP link adapters with the same Silgi semantics — pick whichever fits your stack:
+
+- **`silgi/client/ofetch`** — the default. Uses [ofetch](https://github.com/unjs/ofetch) for retries, timeouts, and interceptors. Stable, widely used, h3/Nuxt-aligned.
+- **`silgi/client/misina`** — an alternative built on [misina](https://github.com/productdevbook/misina). Adds `Retry-After` parsing, distinct `HTTPError`/`NetworkError`/`TimeoutError` classes, and `Idempotency-Key` auto-generation for retried mutations.
 
 ```ts twoslash
 // @noErrors
@@ -226,6 +229,97 @@ Interceptors are useful for:
 - **Logging** in development
 - **Token refresh** — intercept 401 responses, refresh the token, and retry
 - **Metrics** — measure request timing and success rates
+
+## misina link
+
+The misina link is a drop-in alternative to the ofetch link. Same `createLink` shape, same `protocol` selection, same per-call `signal` — different transport with stricter retry and error semantics.
+
+```ts twoslash
+// @noErrors
+import { createClient } from 'silgi/client'
+import { createLink } from 'silgi/client/misina'
+
+const link = createLink({
+  url: 'http://localhost:3000',
+  retry: 2,
+  idempotencyKey: 'auto',
+})
+
+const client = createClient<AppRouter>(link)
+```
+
+### Why pick misina?
+
+- **`Retry-After` and `RateLimit-Reset` parsing** — when the server signals a delay, the link honors it instead of using your fixed backoff.
+- **Distinct error classes** — `HTTPError` (server responded with an error status), `NetworkError` (DNS, connection reset, offline), `TimeoutError` (per-attempt or wall-clock budget exceeded). All are still mapped into `SilgiError` for catch-by-code, but you can introspect the cause via misina's [`isHTTPError` / `isNetworkError` / `isTimeoutError`](https://github.com/productdevbook/misina) guards inside hooks.
+- **Idempotency-Key auto-generation** — retried POST/PATCH/DELETE calls send the same `Idempotency-Key` across attempts so the server can deduplicate. Set `idempotencyKey: 'auto'` to opt in.
+- **Wall-clock timeout** — `timeout` caps each attempt; `totalTimeout` caps the whole logical call (including retry delays).
+- **Redirect security** — sensitive headers are stripped on cross-origin redirects, and `https → http` downgrades are refused.
+
+### Options
+
+| Option            | Type                                                       | Default     | Description                                                                  |
+| ----------------- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `url`             | `string`                                                   | (required)  | Server base URL                                                              |
+| `headers`         | `Record<string, string>` or function                       | `undefined` | Static headers or per-call factory                                           |
+| `retry`           | `number \| boolean \| RetryOptions`                        | `0`         | Number for limit, `false` to disable, or full retry policy object            |
+| `timeout`         | `number \| false`                                          | `30000`     | Per-attempt timeout in ms                                                    |
+| `totalTimeout`    | `number \| false`                                          | `false`     | Wall-clock deadline across all attempts                                      |
+| `protocol`        | `'json' \| 'messagepack' \| 'devalue'`                     | `'json'`    | Wire protocol                                                                |
+| `idempotencyKey`  | `false \| 'auto' \| string \| (req) => string`             | `false`     | Auto-send `Idempotency-Key` on retried mutations                             |
+| `beforeRequest`   | `(ctx) => void \| Request \| Response`                     | —           | Mutate the request, or short-circuit by returning a `Response`               |
+| `afterResponse`   | `(ctx) => void \| Response`                                | —           | Inspect or replace the response after it's received                          |
+| `beforeError`     | `(error, ctx) => Error`                                    | —           | Transform errors before they're thrown                                       |
+| `onComplete`      | `({ request, response, error, durationMs, attempt }) =>`   | —           | Terminal hook — fires once per logical call after retries                    |
+
+### Retry with backoff
+
+Pass a full `RetryOptions` object to tune backoff, retriable status codes, and jitter:
+
+```ts twoslash
+// @noErrors
+const link = createLink({
+  url: 'http://localhost:3000',
+  retry: {
+    limit: 3,
+    delay: (attempt) => 0.3 * 2 ** (attempt - 1) * 1000, // 300ms, 600ms, 1200ms
+    backoffLimit: 30_000,
+    jitter: true,
+    statusCodes: [408, 429, 500, 502, 503, 504],
+  },
+})
+```
+
+### Hooks
+
+misina exposes a lifecycle of typed hooks. The link forwards four of them — use them for logging, metrics, or last-resort error transformation:
+
+```ts twoslash
+// @noErrors
+const link = createLink({
+  url: 'http://localhost:3000',
+  beforeRequest: (ctx) => {
+    ctx.request.headers.set('x-trace-id', crypto.randomUUID())
+  },
+  afterResponse: ({ response }) => {
+    if (response) console.log('status:', response.status)
+  },
+  onComplete: ({ request, durationMs, attempt, error }) => {
+    metrics.observe('rpc.duration', durationMs, {
+      url: request.url,
+      attempts: String(attempt + 1),
+      ok: error ? 'false' : 'true',
+    })
+  },
+})
+```
+
+`onComplete` is the right place for tracing and metrics — it fires exactly once per logical call, after all retries and redirects, with either `response` or `error` populated.
+
+<Callout type='info'>
+  Both links produce the same `SilgiError` instances on failure, so your catch logic doesn't change when you swap. The
+  difference is in the request lifecycle — retries, idempotency, and how the underlying transport classifies failures.
+</Callout>
 
 ## Call options
 

--- a/docs/content/docs/(core)/client.mdx
+++ b/docs/content/docs/(core)/client.mdx
@@ -258,19 +258,19 @@ const client = createClient<AppRouter>(link)
 
 ### Options
 
-| Option            | Type                                                       | Default     | Description                                                                  |
-| ----------------- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
-| `url`             | `string`                                                   | (required)  | Server base URL                                                              |
-| `headers`         | `Record<string, string>` or function                       | `undefined` | Static headers or per-call factory                                           |
-| `retry`           | `number \| boolean \| RetryOptions`                        | `0`         | Number for limit, `false` to disable, or full retry policy object            |
-| `timeout`         | `number \| false`                                          | `30000`     | Per-attempt timeout in ms                                                    |
-| `totalTimeout`    | `number \| false`                                          | `false`     | Wall-clock deadline across all attempts                                      |
-| `protocol`        | `'json' \| 'messagepack' \| 'devalue'`                     | `'json'`    | Wire protocol                                                                |
-| `idempotencyKey`  | `false \| 'auto' \| string \| (req) => string`             | `false`     | Auto-send `Idempotency-Key` on retried mutations                             |
-| `beforeRequest`   | `(ctx) => void \| Request \| Response`                     | —           | Mutate the request, or short-circuit by returning a `Response`               |
-| `afterResponse`   | `(ctx) => void \| Response`                                | —           | Inspect or replace the response after it's received                          |
-| `beforeError`     | `(error, ctx) => Error`                                    | —           | Transform errors before they're thrown                                       |
-| `onComplete`      | `({ request, response, error, durationMs, attempt }) =>`   | —           | Terminal hook — fires once per logical call after retries                    |
+| Option           | Type                                                     | Default     | Description                                                       |
+| ---------------- | -------------------------------------------------------- | ----------- | ----------------------------------------------------------------- |
+| `url`            | `string`                                                 | (required)  | Server base URL                                                   |
+| `headers`        | `Record<string, string>` or function                     | `undefined` | Static headers or per-call factory                                |
+| `retry`          | `number \| boolean \| RetryOptions`                      | `0`         | Number for limit, `false` to disable, or full retry policy object |
+| `timeout`        | `number \| false`                                        | `30000`     | Per-attempt timeout in ms                                         |
+| `totalTimeout`   | `number \| false`                                        | `false`     | Wall-clock deadline across all attempts                           |
+| `protocol`       | `'json' \| 'messagepack' \| 'devalue'`                   | `'json'`    | Wire protocol                                                     |
+| `idempotencyKey` | `false \| 'auto' \| string \| (req) => string`           | `false`     | Auto-send `Idempotency-Key` on retried mutations                  |
+| `beforeRequest`  | `(ctx) => void \| Request \| Response`                   | —           | Mutate the request, or short-circuit by returning a `Response`    |
+| `afterResponse`  | `(ctx) => void \| Response`                              | —           | Inspect or replace the response after it's received               |
+| `beforeError`    | `(error, ctx) => Error`                                  | —           | Transform errors before they're thrown                            |
+| `onComplete`     | `({ request, response, error, durationMs, attempt }) =>` | —           | Terminal hook — fires once per logical call after retries         |
 
 ### Retry with backoff
 

--- a/lib/misina.d.mts
+++ b/lib/misina.d.mts
@@ -1,0 +1,1 @@
+export * from 'misina'

--- a/lib/misina.mjs
+++ b/lib/misina.mjs
@@ -1,0 +1,1 @@
+export * from 'misina'

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
       "import": "./dist/client/adapters/ofetch/index.mjs",
       "types": "./dist/client/adapters/ofetch/index.d.mts"
     },
+    "./client/misina": {
+      "import": "./dist/client/adapters/misina/index.mjs",
+      "types": "./dist/client/adapters/misina/index.d.mts"
+    },
     "./client/plugins": {
       "import": "./dist/client/plugins/index.mjs",
       "types": "./dist/client/plugins/index.d.mts"
@@ -231,6 +235,10 @@
       "import": "./lib/ofetch.mjs",
       "types": "./lib/ofetch.d.mts"
     },
+    "./misina": {
+      "import": "./lib/misina.mjs",
+      "types": "./lib/misina.d.mts"
+    },
     "./srvx": {
       "import": "./lib/srvx.mjs",
       "types": "./lib/srvx.d.mts"
@@ -265,6 +273,7 @@
     "devalue": "^5.6.4",
     "get-port-please": "^3.2.0",
     "hookable": "^6.1.0",
+    "misina": "^0.2.0",
     "msgpackr": "^1.11.9",
     "ocache": "^0.1.4",
     "ofetch": "2.0.0-alpha.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       hookable:
         specifier: ^6.1.0
         version: 6.1.0
+      misina:
+        specifier: ^0.2.0
+        version: 0.2.0
       msgpackr:
         specifier: ^1.11.9
         version: 1.11.9
@@ -1564,8 +1567,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nuxt/cli-nightly@3.34.1-20260415-142813-e14ce27':
-    resolution: {integrity: sha512-dTVNs1Awnq8UqRJmnd7zbb4yYZ5XxmfrrPpnrFtYU9hQG6e2ZwRqT/kkaxxW+IycL0kzzn28hcWCqs0I1R9BTQ==}
+  '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49':
+    resolution: {integrity: sha512-BQTIUm8h/HaKzLmSMuFxEl9IcppItajrf+421CpxNJQcEUX4sA85Jl61Uchy8Aznp9JvQEvUSo0I08Im5f+B9A==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -6664,6 +6667,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  misina@0.2.0:
+    resolution: {integrity: sha512-BfnO+I4exZt3+2IxJdaeZ67QasIeEq+PsGqiD7F/BuJBc2CfPxZPOBBm0Gs4lkXQ0LQ4KL9L7FP1P5xb+2darw==}
+    engines: {node: '>=22.11.0'}
+
   mitata@1.0.34:
     resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
 
@@ -9917,7 +9924,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/cli-nightly@3.34.1-20260415-142813-e14ce27(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)':
+  '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(citty@0.2.2)
       '@clack/prompts': 1.2.0
@@ -15359,6 +15366,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  misina@0.2.0: {}
+
   mitata@1.0.34: {}
 
   mitt@3.0.1: {}
@@ -15687,7 +15696,7 @@ snapshots:
   nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
-      '@nuxt/cli': '@nuxt/cli-nightly@3.34.1-20260415-142813-e14ce27(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
+      '@nuxt/cli': '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
       '@nuxt/devtools': 3.2.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
       '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'
@@ -15821,7 +15830,7 @@ snapshots:
   nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
-      '@nuxt/cli': '@nuxt/cli-nightly@3.34.1-20260415-142813-e14ce27(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
+      '@nuxt/cli': '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
       '@nuxt/devtools': 3.2.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
       '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'

--- a/src/client/adapters/misina/index.ts
+++ b/src/client/adapters/misina/index.ts
@@ -1,0 +1,205 @@
+/**
+ * misina-based RPC transport — v2 client link.
+ *
+ * Uses misina for: retry (with Retry-After parsing), timeout, hook
+ * lifecycle, redirect security, NetworkError vs HTTPError taxonomy,
+ * idempotency keys for retried mutations.
+ *
+ * Side-by-side alternative to the ofetch link. Same Silgi semantics,
+ * different transport. Pick whichever fits your stack.
+ */
+
+import { createMisina, isHTTPError, isNetworkError, isTimeoutError } from 'misina'
+
+import { encode as msgpackEncode, decode as msgpackDecode, MSGPACK_CONTENT_TYPE } from '../../../codec/msgpack.ts'
+import { SilgiError, isSilgiErrorJSON, fromSilgiErrorJSON } from '../../../core/error.ts'
+import { eventStreamToIterator } from '../../../core/sse.ts'
+
+import type { ClientLink, ClientContext, ClientOptions } from '../../types.ts'
+import type { AfterResponseHook, BeforeErrorHook, BeforeRequestHook, MisinaHooks, RetryOptions } from 'misina'
+
+type OnCompleteHook =
+  Exclude<MisinaHooks['onComplete'], undefined> extends infer H ? (H extends readonly (infer U)[] ? U : H) : never
+
+export interface LinkOptions<TClientContext extends ClientContext = ClientContext> {
+  /** Server base URL (e.g. "http://localhost:3000") */
+  url: string
+
+  /** Static headers or dynamic header factory */
+  headers?: Record<string, string> | ((options: ClientOptions<TClientContext>) => Record<string, string>)
+
+  /**
+   * Retry policy. Number sets the limit; pass a full `RetryOptions` to
+   * tune backoff, status codes, jitter. `false` disables retries.
+   *
+   * @default 0
+   */
+  retry?: number | boolean | RetryOptions
+
+  /** Per-attempt timeout in ms. `false` disables. (default: 30000) */
+  timeout?: number | false
+
+  /** Wall-clock deadline across all attempts (ms). `false` disables. */
+  totalTimeout?: number | false
+
+  /**
+   * Wire protocol for request/response encoding.
+   *
+   * - `'json'` — default, standard JSON
+   * - `'messagepack'` — 2-4x faster, ~50% smaller payloads
+   * - `'devalue'` — preserves Date, Map, Set, BigInt, circular refs
+   *
+   * @default 'json'
+   */
+  protocol?: 'json' | 'messagepack' | 'devalue'
+
+  /**
+   * Auto-generate `Idempotency-Key` for retried mutations. `'auto'` uses
+   * `crypto.randomUUID()` when retries are enabled. Pass a string to
+   * pin one, or a function for custom generation.
+   */
+  idempotencyKey?: false | 'auto' | string | ((request: Request) => string)
+
+  /** misina hooks — direct pass-through */
+  beforeRequest?: BeforeRequestHook
+  afterResponse?: AfterResponseHook
+  beforeError?: BeforeErrorHook
+  onComplete?: OnCompleteHook
+}
+
+/**
+ * Create a Silgi client link powered by misina.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from "silgi/client"
+ * import { createLink } from "silgi/client/misina"
+ *
+ * const link = createLink({ url: "http://localhost:3000" })
+ * const client = createClient<AppRouter>(link)
+ * const users = await client.users.list({ limit: 10 })
+ * ```
+ */
+export function createLink<TClientContext extends ClientContext = ClientContext>(
+  options: LinkOptions<TClientContext>,
+): ClientLink<TClientContext> {
+  const baseUrl = options.url.endsWith('/') ? options.url.slice(0, -1) : options.url
+  const resolvedProtocol: 'json' | 'messagepack' | 'devalue' = options.protocol ?? 'json'
+
+  const misina = createMisina({
+    timeout: options.timeout ?? 30_000,
+    totalTimeout: options.totalTimeout,
+    retry: options.retry ?? 0,
+    idempotencyKey: options.idempotencyKey,
+    throwHttpErrors: false,
+    hooks: {
+      beforeRequest: options.beforeRequest,
+      afterResponse: options.afterResponse,
+      beforeError: options.beforeError,
+      onComplete: options.onComplete,
+    },
+  })
+
+  return {
+    async call(path, input, callOptions) {
+      const url = `${baseUrl}/${path.map(encodeURIComponent).join('/')}`
+
+      // Resolve headers
+      const headers: Record<string, string> = {
+        ...(typeof options.headers === 'function' ? options.headers(callOptions) : options.headers),
+      }
+
+      // Protocol selection: messagepack > devalue > json (default)
+      let body: unknown
+      if (resolvedProtocol === 'messagepack') {
+        headers['content-type'] = MSGPACK_CONTENT_TYPE
+        headers['accept'] = MSGPACK_CONTENT_TYPE
+        body = input !== undefined && input !== null ? msgpackEncode(input) : undefined
+      } else if (resolvedProtocol === 'devalue') {
+        const { encode: devalueEncode, DEVALUE_CONTENT_TYPE } = await import('../../../codec/devalue.ts')
+        headers['content-type'] = DEVALUE_CONTENT_TYPE
+        headers['accept'] = DEVALUE_CONTENT_TYPE
+        body = input !== undefined && input !== null ? devalueEncode(input) : undefined
+      } else {
+        body = input !== undefined && input !== null ? input : undefined
+      }
+
+      try {
+        // `responseType: 'stream'` keeps misina from consuming the body
+        // so we can branch on `content-type`: subscriptions need the
+        // raw stream for SSE decoding, while query/mutation responses
+        // get decoded here per protocol.
+        const result = await misina.post(url, body, {
+          headers,
+          signal: callOptions.signal,
+          responseType: 'stream',
+        })
+
+        const response = result.raw
+
+        // Subscription response — server emitted an async iterator as SSE.
+        const responseContentType = response.headers.get('content-type') ?? ''
+        if (responseContentType.includes('text/event-stream') && response.body) {
+          return eventStreamToIterator(response.body)
+        }
+
+        // Query/mutation — drain the stream and decode per protocol.
+        let decoded: unknown
+        if (resolvedProtocol === 'messagepack') {
+          const buf = new Uint8Array(await response.arrayBuffer())
+          decoded = buf.length > 0 ? msgpackDecode(buf) : undefined
+        } else if (resolvedProtocol === 'devalue') {
+          const text = await response.text()
+          if (text) {
+            const { decode: devalueDecode } = await import('../../../codec/devalue.ts')
+            decoded = devalueDecode(text)
+          } else {
+            decoded = undefined
+          }
+        } else {
+          const text = await response.text()
+          if (!text) {
+            decoded = undefined
+          } else {
+            try {
+              decoded = JSON.parse(text)
+            } catch {
+              decoded = text
+            }
+          }
+        }
+
+        if (isSilgiErrorJSON(decoded)) {
+          throw fromSilgiErrorJSON(decoded as any)
+        }
+
+        return decoded
+      } catch (error) {
+        // Re-throw SilgiError as-is
+        if (error instanceof SilgiError) throw error
+
+        // misina HTTPError carries server payload — try to lift SilgiError shape
+        if (isHTTPError(error)) {
+          const data = (error as any).data
+          if (isSilgiErrorJSON(data)) {
+            throw fromSilgiErrorJSON(data)
+          }
+          throw new SilgiError('INTERNAL_SERVER_ERROR', {
+            status: (error as any).status ?? 500,
+            message: (error as Error).message,
+            data,
+          })
+        }
+
+        if (isNetworkError(error) || isTimeoutError(error)) {
+          throw new SilgiError('INTERNAL_SERVER_ERROR', {
+            status: 0,
+            message: (error as Error).message,
+          })
+        }
+
+        throw error
+      }
+    },
+  }
+}

--- a/test/client/misina.test.ts
+++ b/test/client/misina.test.ts
@@ -1,0 +1,249 @@
+/**
+ * misina client link — integration tests.
+ *
+ * Spins up a real silgi server and tests the misina-based client.
+ */
+
+import { createServer } from 'node:http'
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { z } from 'zod'
+
+import { createLink } from '#src/client/adapters/misina/index.ts'
+import { createClient } from '#src/client/client.ts'
+import { silgi } from '#src/silgi.ts'
+
+import type { InferClient } from '#src/types.ts'
+import type { Server } from 'node:http'
+
+// ── Server Setup ────────────────────────────────────
+
+const k = silgi({
+  context: () => ({
+    db: {
+      users: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+    },
+  }),
+})
+
+const auth = k.guard(() => ({ userId: 1 }))
+
+const appRouter = k.router({
+  health: k.$resolve(() => ({ status: 'ok', ts: Date.now() })),
+  users: {
+    list: k.$input(z.object({ limit: z.number().optional() })).$resolve(({ input, ctx }) => {
+      const limit = input.limit ?? 10
+      return ctx.db.users.slice(0, limit)
+    }),
+    get: k.$input(z.object({ id: z.number() })).$resolve(({ input, ctx }) => {
+      const user = ctx.db.users.find((u) => u.id === input.id)
+      if (!user) throw new Error('Not found')
+      return user
+    }),
+    create: k
+      .$use(auth)
+      .$input(z.object({ name: z.string().min(1) }))
+      .$errors({ CONFLICT: 409 })
+      .$resolve(({ input }) => ({ id: 3, name: input.name })),
+  },
+  echo: k.$input(z.object({ message: z.string() })).$resolve(({ input }) => ({ echo: input.message })),
+})
+
+type AppRouter = typeof appRouter
+
+const handle = k.handler(appRouter)
+
+let server: Server
+let baseUrl: string
+
+beforeAll(async () => {
+  server = createServer(async (req, res) => {
+    const url = `http://localhost${req.url}`
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value) headers.set(key, Array.isArray(value) ? value[0]! : value)
+    }
+
+    let body: string | undefined
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      body = await new Promise<string>((resolve) => {
+        let data = ''
+        req.on('data', (chunk: Buffer) => {
+          data += chunk
+        })
+        req.on('end', () => resolve(data))
+      })
+    }
+
+    const fetchReq = new Request(url, {
+      method: req.method,
+      headers,
+      body: body || undefined,
+    })
+
+    const fetchRes = await handle(fetchReq)
+    res.writeHead(fetchRes.status, Object.fromEntries(fetchRes.headers))
+    const resBody = await fetchRes.text()
+    res.end(resBody)
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number }
+      baseUrl = `http://127.0.0.1:${addr.port}`
+      resolve()
+    })
+  })
+})
+
+afterAll(() => {
+  server?.close()
+})
+
+// ── Tests ───────────────────────────────────────────
+
+describe('misina client link', () => {
+  it('creates a typed client and calls a no-input query', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const result = await client.health()
+    expect(result.status).toBe('ok')
+    expect(typeof result.ts).toBe('number')
+  })
+
+  it('calls a query with input', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const result = await client.echo({ message: 'hello' })
+    expect(result.echo).toBe('hello')
+  })
+
+  it('calls nested procedures', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const users = await client.users.list({ limit: 1 })
+    expect(users).toHaveLength(1)
+    expect(users[0]!.name).toBe('Alice')
+  })
+
+  it('calls mutation with input', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const user = await client.users.create({ name: 'Charlie' })
+    expect(user.id).toBe(3)
+    expect(user.name).toBe('Charlie')
+  })
+
+  it('handles validation errors', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    await expect(client.users.create({ name: '' })).rejects.toThrow()
+  })
+
+  it('handles 404 for unknown routes', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link as any)
+
+    await expect((client as any).nonexistent()).rejects.toThrow()
+  })
+
+  it('supports custom headers', async () => {
+    const link = createLink({
+      url: baseUrl,
+      headers: { 'x-custom': 'test-value' },
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const result = await client.health()
+    expect(result.status).toBe('ok')
+  })
+
+  it('supports dynamic headers', async () => {
+    let headersCalled = false
+    const link = createLink({
+      url: baseUrl,
+      headers: () => {
+        headersCalled = true
+        return { authorization: 'Bearer test' }
+      },
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    await client.health()
+    expect(headersCalled).toBe(true)
+  })
+
+  it('supports timeout', async () => {
+    const link = createLink({
+      url: baseUrl,
+      timeout: 5000,
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const result = await client.health()
+    expect(result.status).toBe('ok')
+  })
+
+  it('supports AbortSignal', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(client.health(undefined, { signal: controller.signal })).rejects.toThrow()
+  })
+
+  it('supports beforeRequest hook', async () => {
+    let intercepted = false
+    const link = createLink({
+      url: baseUrl,
+      beforeRequest: () => {
+        intercepted = true
+      },
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    await client.health()
+    expect(intercepted).toBe(true)
+  })
+
+  it('supports afterResponse hook', async () => {
+    let responseStatus = 0
+    const link = createLink({
+      url: baseUrl,
+      afterResponse: ({ response }) => {
+        if (response) responseStatus = response.status
+      },
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    await client.health()
+    expect(responseStatus).toBe(200)
+  })
+
+  it('supports onComplete terminal hook', async () => {
+    let completed = false
+    let durationMs = -1
+    const link = createLink({
+      url: baseUrl,
+      onComplete: (info) => {
+        completed = true
+        durationMs = info.durationMs
+      },
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    await client.health()
+    expect(completed).toBe(true)
+    expect(durationMs).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'src/client/index.ts',
     'src/client/adapters/fetch/index.ts',
     'src/client/adapters/ofetch/index.ts',
+    'src/client/adapters/misina/index.ts',
     'src/client/plugins/index.ts',
     'src/client/adapters/websocket/index.ts',
     'src/client/consume.ts',


### PR DESCRIPTION
## Summary
- Adds a new `silgi/client/misina` adapter as a side-by-side alternative to the existing ofetch link — same Silgi semantics (3 wire protocols, SSE subscriptions, `SilgiError` mapping), different transport.
- ofetch link is untouched and remains the default. Users can opt into misina for `Retry-After`/`RateLimit-Reset` parsing, `HTTPError`/`NetworkError`/`TimeoutError` taxonomy, and `Idempotency-Key` auto-gen on retried mutations.
- Mirrors the ofetch package surface: `./client/misina` link export and `./misina` re-export of the upstream package (parallel to `./ofetch`).

## Usage
```ts
import { createLink } from 'silgi/client/misina'
const link = createLink({ url: 'http://localhost:3000', retry: 2, idempotencyKey: 'auto' })
```

## Test plan
- [x] `pnpm test test/client/misina.test.ts` — 13/13 passing (mirrors the ofetch test suite)
- [x] `pnpm test` — full suite 938 passing, no regressions
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)