### PR TITLE
fix(types): wrap subscription InferClient output in Promise (#29)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -155,9 +155,14 @@ export type RouterDef = {
 // Re-export for circular dependency avoidance
 import type { TaskDef } from './core/task.ts'
 
-/** Return type wrapper — subscription yields, query/mutation returns Promise */
+/**
+ * Return type wrapper — every procedure call resolves through the link's
+ * async `call`, so the client always returns a `Promise`. Subscriptions
+ * resolve to an `AsyncIterableIterator` (the open SSE/WS stream); queries
+ * and mutations resolve to the procedure's output value.
+ */
 type ProcedureResult<TType extends ProcedureType, TOutput> = TType extends 'subscription'
-  ? AsyncIterableIterator<TOutput>
+  ? Promise<AsyncIterableIterator<TOutput>>
   : Promise<TOutput>
 
 /** Infer client type from router */

--- a/test/core/types.test.ts
+++ b/test/core/types.test.ts
@@ -376,23 +376,23 @@ describe('InferClient', () => {
     }>()
   })
 
-  it('subscription — returns AsyncIterableIterator', () => {
+  it('subscription — returns Promise<AsyncIterableIterator>', () => {
     const stream = k.subscription(async function* () {
       yield { tick: 1, time: 'now' }
     })
 
     type Client = InferClient<typeof stream>
-    expectTypeOf<Client>().toEqualTypeOf<() => AsyncIterableIterator<{ tick: number; time: string }>>()
+    expectTypeOf<Client>().toEqualTypeOf<() => Promise<AsyncIterableIterator<{ tick: number; time: string }>>>()
   })
 
-  it('subscription with input — takes input, returns AsyncIterableIterator', () => {
+  it('subscription with input — takes input, returns Promise<AsyncIterableIterator>', () => {
     const stream = k.subscription(z.object({ channel: z.string() }), async function* ({ input }) {
       yield { channel: input.channel, message: 'hello' }
     })
 
     type Client = InferClient<typeof stream>
     expectTypeOf<Client>().toEqualTypeOf<
-      (input: { channel: string }) => AsyncIterableIterator<{ channel: string; message: string }>
+      (input: { channel: string }) => Promise<AsyncIterableIterator<{ channel: string; message: string }>>
     >()
   })
 
@@ -419,8 +419,8 @@ describe('InferClient', () => {
         create: (input: { name: string }) => Promise<{ id: number; name: string }>
       }
       stream: {
-        ticks: () => AsyncIterableIterator<{ tick: number }>
-        messages: (input: { roomId: string }) => AsyncIterableIterator<{ roomId: string; text: string }>
+        ticks: () => Promise<AsyncIterableIterator<{ tick: number }>>
+        messages: (input: { roomId: string }) => Promise<AsyncIterableIterator<{ roomId: string; text: string }>>
       }
     }>()
   })

--- a/test/integrations/pinia-colada.test.ts
+++ b/test/integrations/pinia-colada.test.ts
@@ -334,4 +334,28 @@ describe('pinia-colada type inference', () => {
     expectTypeOf<ReturnType<Utils['key']>>().toEqualTypeOf<EntryKey>()
     expectTypeOf<ReturnType<Utils['users']['key']>>().toEqualTypeOf<EntryKey>()
   })
+
+  // Regression: https://github.com/productdevbook/silgi/issues/29
+  // A subscription procedure used to be inferred as `() => AsyncIterableIterator<T>`
+  // which doesn't satisfy `SubscriptionClient` (which expects `Promise<AsyncIterableIterator<T>>`),
+  // collapsing `T extends NestedClient` and producing a union of three RouterUtils arms.
+  it('RouterUtils accepts routers containing subscription procedures', () => {
+    const subRouter = k.router({
+      api: {
+        chat: k.subscription(z.object({ message: z.string() }), async function* ({ input }) {
+          yield { type: 'text-delta' as const, delta: input.message }
+          yield { type: 'done' as const }
+        }),
+        health: k.$resolve(() => ({ status: 'ok' as const })),
+      },
+    })
+
+    type SubClient = InferClient<typeof subRouter>
+    type Utils = RouterUtils<SubClient>
+
+    expectTypeOf<Utils['key']>().toBeFunction()
+    expectTypeOf<Utils['api']['key']>().toBeFunction()
+    expectTypeOf<Utils['api']['chat']>().toHaveProperty('queryOptions')
+    expectTypeOf<Utils['api']['health']>().toHaveProperty('queryOptions')
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #29 — `createColadaUtils(client)` (and any `T extends NestedClient` consumer) rejecting routers that contain a `subscription` procedure with a misleading `TS2345` + `TS2339` cascade.
- Root cause: `ProcedureResult` in `src/types.ts` produced `AsyncIterableIterator<T>` for subscriptions, while `SubscriptionClient` (`src/client/types.ts`) and the actual runtime contract are both `Promise<AsyncIterableIterator<T>>`. The mismatch failed the `NestedClient` constraint and collapsed `RouterUtils<T>` into a three-arm union.
- One-line type fix; aligns with what the runtime has been doing all along (`client.ts` returns the `link.call(...)` `Promise` for every procedure type, and `ws-link.test.ts` already does `await client.ticks()`).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 939 passed / 19 skipped (pre-existing); the two assertions in `core/types.test.ts` that previously pinned the buggy shape are updated to match the corrected contract
- [x] New regression test in `test/integrations/pinia-colada.test.ts` mirroring the minimal repro from #29 (router with a `subscription` + a regular procedure → `RouterUtils<…>` resolves cleanly)
- [ ] Reviewer to confirm no downstream consumer relied on the missing `Promise` wrap (search of the repo turned up none — every subscription consumption site already `await`s)

## Notes for reviewer
- `ProcedureResult` change is the only behavior-relevant edit; the test diffs are correcting assertions that locked in the wrong shape (which is why the regression slipped through).
- The defensive `RouterUtils<T>` tightening discussed in the issue (constraining the leaf arm to pure callables) is intentionally **not** in this patch — it's a separate quality-of-error change worth shipping on its own once this fix lands.
- Orphan `silgi@0.53.{0,2,3}` dirs in `node_modules/.pnpm/` mentioned in the issue thread are unrelated to this bug; `pnpm prune` clears them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)