### PR TITLE
feat(client/misina)!: instance-only API, drop flat option re-exports

### DIFF
--- a/docs/content/docs/(core)/client.mdx
+++ b/docs/content/docs/(core)/client.mdx
@@ -21,7 +21,7 @@ Setting up the client takes two steps: create a **link** (the transport layer) a
 A link tells the client _how_ to send requests to the server. Silgi ships two HTTP link adapters with the same Silgi semantics — pick whichever fits your stack:
 
 - **`silgi/client/ofetch`** — the default. Uses [ofetch](https://github.com/unjs/ofetch) for retries, timeouts, and interceptors. Stable, widely used, h3/Nuxt-aligned.
-- **`silgi/client/misina`** — an alternative built on [misina](https://github.com/productdevbook/misina). Adds `Retry-After` parsing, distinct `HTTPError`/`NetworkError`/`TimeoutError` classes, and `Idempotency-Key` auto-generation for retried mutations.
+- **`silgi/client/misina`** — an alternative built on [misina](https://github.com/productdevbook/misina). Adds `Retry-After` parsing, distinct `HTTPError`/`NetworkError`/`TimeoutError` classes, `Idempotency-Key` auto-generation for retried mutations, and a plugin ecosystem (cache, breaker, dedupe, cookies, auth, otel, tracing).
 
 ```ts twoslash
 // @noErrors
@@ -232,93 +232,143 @@ Interceptors are useful for:
 
 ## misina link
 
-The misina link is a drop-in alternative to the ofetch link. Same `createLink` shape, same `protocol` selection, same per-call `signal` — different transport with stricter retry and error semantics.
+The misina link is an alternative transport with stricter retry semantics, distinct error classes, and a plugin ecosystem. Unlike the ofetch link, transport configuration lives on a `Misina` instance you build with `createMisina(...)` and pass through — the link itself only handles silgi-specific concerns (URL construction, protocol negotiation, SSE branching, `SilgiError` lifting).
 
 ```ts twoslash
 // @noErrors
+import { createMisina } from 'misina'
 import { createClient } from 'silgi/client'
 import { createLink } from 'silgi/client/misina'
 
 const link = createLink({
   url: 'http://localhost:3000',
-  retry: 2,
-  idempotencyKey: 'auto',
+  misina: createMisina({
+    retry: 2,
+    idempotencyKey: 'auto',
+  }),
 })
 
 const client = createClient<AppRouter>(link)
 ```
 
+If you omit `misina`, the adapter constructs a minimal default (`createMisina({ baseURL: url })`) — fine for plain RPC, but you opt into retries, hooks, plugins, etc. by passing your own.
+
 ### Why pick misina?
 
-- **`Retry-After` and `RateLimit-Reset` parsing** — when the server signals a delay, the link honors it instead of using your fixed backoff.
-- **Distinct error classes** — `HTTPError` (server responded with an error status), `NetworkError` (DNS, connection reset, offline), `TimeoutError` (per-attempt or wall-clock budget exceeded). All are still mapped into `SilgiError` for catch-by-code, but you can introspect the cause via misina's [`isHTTPError` / `isNetworkError` / `isTimeoutError`](https://github.com/productdevbook/misina) guards inside hooks.
-- **Idempotency-Key auto-generation** — retried POST/PATCH/DELETE calls send the same `Idempotency-Key` across attempts so the server can deduplicate. Set `idempotencyKey: 'auto'` to opt in.
+- **`Retry-After` and `RateLimit-Reset` parsing** — when the server signals a delay, the transport honors it instead of using fixed backoff.
+- **Distinct error classes** — `HTTPError` (server responded with an error status), `NetworkError` (DNS, connection reset, offline), `TimeoutError` (per-attempt or wall-clock budget exceeded). All map into `SilgiError` for catch-by-code, but you can introspect the cause via misina's [`isHTTPError` / `isNetworkError` / `isTimeoutError`](https://github.com/productdevbook/misina) guards.
+- **Idempotency-Key auto-generation** — retried POST/PATCH/DELETE calls send the same `Idempotency-Key` across attempts so the server can deduplicate. Set `idempotencyKey: 'auto'` on the misina instance.
 - **Wall-clock timeout** — `timeout` caps each attempt; `totalTimeout` caps the whole logical call (including retry delays).
 - **Redirect security** — sensitive headers are stripped on cross-origin redirects, and `https → http` downgrades are refused.
+- **Plugin ecosystem** — `cache`, `breaker`, `dedupe`, `cookieJar`, `bearer`, `refreshOn401`, `sigv4`, `otel`, `tracing`, `ratelimit` — all compose via `createMisina({ use: [...] })`.
 
-### Options
+### Link options
 
-| Option           | Type                                                     | Default     | Description                                                       |
-| ---------------- | -------------------------------------------------------- | ----------- | ----------------------------------------------------------------- |
-| `url`            | `string`                                                 | (required)  | Server base URL                                                   |
-| `headers`        | `Record<string, string>` or function                     | `undefined` | Static headers or per-call factory                                |
-| `retry`          | `number \| boolean \| RetryOptions`                      | `0`         | Number for limit, `false` to disable, or full retry policy object |
-| `timeout`        | `number \| false`                                        | `30000`     | Per-attempt timeout in ms                                         |
-| `totalTimeout`   | `number \| false`                                        | `false`     | Wall-clock deadline across all attempts                           |
-| `protocol`       | `'json' \| 'messagepack' \| 'devalue'`                   | `'json'`    | Wire protocol                                                     |
-| `idempotencyKey` | `false \| 'auto' \| string \| (req) => string`           | `false`     | Auto-send `Idempotency-Key` on retried mutations                  |
-| `beforeRequest`  | `(ctx) => void \| Request \| Response`                   | —           | Mutate the request, or short-circuit by returning a `Response`    |
-| `afterResponse`  | `(ctx) => void \| Response`                              | —           | Inspect or replace the response after it's received               |
-| `beforeError`    | `(error, ctx) => Error`                                  | —           | Transform errors before they're thrown                            |
-| `onComplete`     | `({ request, response, error, durationMs, attempt }) =>` | —           | Terminal hook — fires once per logical call after retries         |
+The link surface itself is intentionally small. Configure transport behavior on the misina instance.
+
+| Option     | Type                                                   | Default     | Description                                                                       |
+| ---------- | ------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------- |
+| `url`      | `string`                                               | (required)  | Server base URL                                                                   |
+| `misina`   | `Misina`                                               | `undefined` | Pre-configured misina instance. Defaults to `createMisina({ baseURL: url })`.     |
+| `protocol` | `'json' \| 'messagepack' \| 'devalue'`                 | `'json'`    | Wire protocol                                                                     |
+| `headers`  | `HeadersInit \| Record<string, string \| undefined>` or function | `undefined` | Static headers or per-call factory. Merged on top of headers from the misina instance. |
+
+For everything else — retry, timeout, totalTimeout, hooks, idempotencyKey, validateResponse, redirect policy, plugins, custom drivers, request id headers, body timeouts, max response size — see the [misina docs](https://github.com/productdevbook/misina).
 
 ### Retry with backoff
 
-Pass a full `RetryOptions` object to tune backoff, retriable status codes, and jitter:
+Configure on the instance:
 
 ```ts twoslash
 // @noErrors
+import { createMisina } from 'misina'
+
 const link = createLink({
   url: 'http://localhost:3000',
-  retry: {
-    limit: 3,
-    delay: (attempt) => 0.3 * 2 ** (attempt - 1) * 1000, // 300ms, 600ms, 1200ms
-    backoffLimit: 30_000,
-    jitter: true,
-    statusCodes: [408, 429, 500, 502, 503, 504],
-  },
+  misina: createMisina({
+    retry: {
+      limit: 3,
+      delay: (attempt) => 0.3 * 2 ** (attempt - 1) * 1000, // 300ms, 600ms, 1200ms
+      backoffLimit: 30_000,
+      jitter: true,
+      statusCodes: [408, 429, 500, 502, 503, 504],
+    },
+  }),
 })
 ```
 
 ### Hooks
 
-misina exposes a lifecycle of typed hooks. The link forwards four of them — use them for logging, metrics, or last-resort error transformation:
+misina exposes a typed lifecycle (`init`, `beforeRequest`, `beforeRetry`, `beforeRedirect`, `afterResponse`, `beforeError`, `onComplete`). Pass them through `createMisina({ hooks: { ... } })`:
 
 ```ts twoslash
 // @noErrors
+import { createMisina } from 'misina'
+
 const link = createLink({
   url: 'http://localhost:3000',
-  beforeRequest: (ctx) => {
-    ctx.request.headers.set('x-trace-id', crypto.randomUUID())
-  },
-  afterResponse: ({ response }) => {
-    if (response) console.log('status:', response.status)
-  },
-  onComplete: ({ request, durationMs, attempt, error }) => {
-    metrics.observe('rpc.duration', durationMs, {
-      url: request.url,
-      attempts: String(attempt + 1),
-      ok: error ? 'false' : 'true',
-    })
-  },
+  misina: createMisina({
+    hooks: {
+      beforeRequest: (ctx) => {
+        const headers = new Headers(ctx.request.headers)
+        headers.set('x-trace-id', crypto.randomUUID())
+        return new Request(ctx.request, { headers })
+      },
+      afterResponse: ({ response }) => {
+        if (response) console.log('status:', response.status)
+      },
+      onComplete: ({ request, durationMs, attempt, error }) => {
+        metrics.observe('rpc.duration', durationMs, {
+          url: request.url,
+          attempts: String(attempt + 1),
+          ok: error ? 'false' : 'true',
+        })
+      },
+    },
+  }),
 })
 ```
 
 `onComplete` is the right place for tracing and metrics — it fires exactly once per logical call, after all retries and redirects, with either `response` or `error` populated.
 
+### Plugins
+
+Cross-cutting features (auth, cache, cookies, dedupe, breaker, rate limit, tracing, …) ship as misina plugins. Compose them on the instance via `use: [...]`:
+
+```ts twoslash
+// @noErrors
+import { createMisina } from 'misina'
+import { bearer, refreshOn401 } from 'misina/auth'
+import { cache, memoryStore } from 'misina/cache'
+import { breaker } from 'misina/breaker'
+import { dedupe } from 'misina/dedupe'
+
+const link = createLink({
+  url: 'http://localhost:3000',
+  misina: createMisina({
+    baseURL: 'http://localhost:3000',
+    retry: 3,
+    idempotencyKey: 'auto',
+    use: [
+      bearer(() => store.token),
+      refreshOn401({ refresh: async () => fetchNewToken() }),
+      cache({ store: memoryStore({ max: 500 }), ttl: 60_000 }),
+      breaker({ failureThreshold: 5, windowMs: 30_000 }),
+      dedupe(),
+    ],
+  }),
+})
+```
+
+Plugins apply left-to-right (first is innermost). The full set is documented in the [misina README](https://github.com/productdevbook/misina#plugins-use-).
+
 <Callout type='info'>
   Both links produce the same `SilgiError` instances on failure, so your catch logic doesn't change when you swap. The
   difference is in the request lifecycle — retries, idempotency, and how the underlying transport classifies failures.
+</Callout>
+
+<Callout type='warn'>
+  The adapter forces `responseType: 'stream'` and `throwHttpErrors: false` per call, regardless of your instance defaults — both are required for SSE subscription branching and `SilgiError` lifting. Every other misina option flows through unchanged.
 </Callout>
 
 ## Call options

--- a/docs/content/docs/(core)/client.mdx
+++ b/docs/content/docs/(core)/client.mdx
@@ -266,11 +266,11 @@ If you omit `misina`, the adapter constructs a minimal default (`createMisina({ 
 
 The link surface itself is intentionally small. Configure transport behavior on the misina instance.
 
-| Option     | Type                                                   | Default     | Description                                                                       |
-| ---------- | ------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------- |
-| `url`      | `string`                                               | (required)  | Server base URL                                                                   |
-| `misina`   | `Misina`                                               | `undefined` | Pre-configured misina instance. Defaults to `createMisina({ baseURL: url })`.     |
-| `protocol` | `'json' \| 'messagepack' \| 'devalue'`                 | `'json'`    | Wire protocol                                                                     |
+| Option     | Type                                                             | Default     | Description                                                                            |
+| ---------- | ---------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `url`      | `string`                                                         | (required)  | Server base URL                                                                        |
+| `misina`   | `Misina`                                                         | `undefined` | Pre-configured misina instance. Defaults to `createMisina({ baseURL: url })`.          |
+| `protocol` | `'json' \| 'messagepack' \| 'devalue'`                           | `'json'`    | Wire protocol                                                                          |
 | `headers`  | `HeadersInit \| Record<string, string \| undefined>` or function | `undefined` | Static headers or per-call factory. Merged on top of headers from the misina instance. |
 
 For everything else — retry, timeout, totalTimeout, hooks, idempotencyKey, validateResponse, redirect policy, plugins, custom drivers, request id headers, body timeouts, max response size — see the [misina docs](https://github.com/productdevbook/misina).
@@ -368,7 +368,9 @@ Plugins apply left-to-right (first is innermost). The full set is documented in 
 </Callout>
 
 <Callout type='warn'>
-  The adapter forces `responseType: 'stream'` and `throwHttpErrors: false` per call, regardless of your instance defaults — both are required for SSE subscription branching and `SilgiError` lifting. Every other misina option flows through unchanged.
+  The adapter forces `responseType: 'stream'` and `throwHttpErrors: false` per call, regardless of your instance
+  defaults — both are required for SSE subscription branching and `SilgiError` lifting. Every other misina option flows
+  through unchanged.
 </Callout>
 
 ## Call options

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "devalue": "^5.6.4",
     "get-port-please": "^3.2.0",
     "hookable": "^6.1.0",
-    "misina": "^0.2.0",
+    "misina": "^0.4.0",
     "msgpackr": "^1.11.9",
     "ocache": "^0.1.4",
     "ofetch": "2.0.0-alpha.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       misina:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.4.0
+        version: 0.4.0(undici@7.24.4)
       msgpackr:
         specifier: ^1.11.9
         version: 1.11.9
@@ -71,7 +71,7 @@ importers:
         version: 1.19.11(hono@4.12.9)
       '@nuxt/test-utils':
         specifier: ^4.0.0
-        version: 4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@orpc/client':
         specifier: ^1.13.13
         version: 1.13.13(@opentelemetry/api@1.9.0)
@@ -134,16 +134,16 @@ importers:
         version: 2.29.3
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       nuxt-nightly:
         specifier: 5.0.0-29563820.579db312
-        version: 5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       obuild:
         specifier: ^0.4.32
         version: 0.4.32(@typescript/native-preview@7.0.0-dev.20260316.1)(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(jiti@2.6.1)(magicast@0.5.2)(picomatch@4.0.4)(rollup@4.59.0)(typescript@6.0.2)
       oxc-parser:
         specifier: ^0.123.0
-        version: 0.123.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+        version: 0.123.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       oxfmt:
         specifier: ^0.42.0
         version: 0.42.0
@@ -164,7 +164,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: ^3.5.31
         version: 3.5.31(typescript@6.0.2)
@@ -450,19 +450,19 @@ importers:
     devDependencies:
       nitro:
         specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/nuxt:
     dependencies:
       '@nuxtjs/tailwindcss':
         specifier: 7.0.0-beta.1
-        version: 7.0.0-beta.1(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 7.0.0-beta.1(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       nats:
         specifier: ^2.29.3
         version: 2.29.3
       nuxt:
         specifier: npm:nuxt-nightly@5x
-        version: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       silgi:
         specifier: link:../..
         version: link:../..
@@ -915,17 +915,17 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -2182,8 +2182,8 @@ packages:
   '@oxc-project/types@0.123.0':
     resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxc-transform/binding-android-arm-eabi@0.120.0':
     resolution: {integrity: sha512-NRSGsDmnVYWMnYq4LlxakKbZUFhV+A9cVIwQu/Iy/eZcADxT3eSRJ8ItLbAryMjuuWJiCQFdlGNMFzuMtHogzw==}
@@ -3060,8 +3060,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3078,8 +3078,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -3096,8 +3096,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3114,8 +3114,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -3132,8 +3132,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3151,8 +3151,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3172,8 +3172,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3193,8 +3193,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3214,8 +3214,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -3235,8 +3235,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3256,8 +3256,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3276,8 +3276,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3293,9 +3293,9 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
@@ -3309,8 +3309,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3327,8 +3327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3348,8 +3348,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.13':
     resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -5329,6 +5329,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -6667,9 +6670,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  misina@0.2.0:
-    resolution: {integrity: sha512-BfnO+I4exZt3+2IxJdaeZ67QasIeEq+PsGqiD7F/BuJBc2CfPxZPOBBm0Gs4lkXQ0LQ4KL9L7FP1P5xb+2darw==}
+  misina@0.4.0:
+    resolution: {integrity: sha512-s8TkSGRrw0or6JBN2STCZVHoCxFi6t9ilsFCB/LKDMQSk/jUEzfdacECzEiz+KAjTxMRgSWMCvEJTIsC5chgPw==}
     engines: {node: '>=22.11.0'}
+    peerDependencies:
+      undici: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      undici:
+        optional: true
 
   mitata@1.0.34:
     resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
@@ -6924,6 +6932,11 @@ packages:
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7183,8 +7196,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -7566,8 +7579,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7994,6 +8007,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -8484,14 +8501,14 @@ packages:
       vite: ^6.0.0 || ^7.0.0
       vue: ^3.5.0
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -8527,14 +8544,14 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -9364,24 +9381,24 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.9.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9864,17 +9881,17 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -9933,14 +9950,14 @@ snapshots:
       confbox: 0.2.4
       consola: 3.4.2
       debug: 4.4.3
-      defu: 6.1.7
+      defu: 6.1.4
       exsolve: 1.0.8
       fuse.js: 7.3.0
       fzf: 0.5.2
       giget: 3.2.0
       jiti: 2.6.1
       listhen: 1.9.1(srvx@0.11.13)
-      nypm: 0.6.5
+      nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9962,19 +9979,19 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
@@ -9989,9 +10006,9 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))':
+  '@nuxt/devtools@3.2.4(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vue/devtools-core': 8.1.0(vue@3.5.31(typescript@6.0.2))
@@ -10019,9 +10036,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.15
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      vite-plugin-vue-tracer: 1.3.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-tracer: 1.3.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       which: 6.0.1
       ws: 8.20.0
     transitivePeerDependencies:
@@ -10034,15 +10051,15 @@ snapshots:
     dependencies:
       c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       destr: 2.0.5
       errx: 0.1.0
       exsolve: 1.0.8
       ignore: 7.0.5
       jiti: 2.6.1
       klona: 2.0.6
-      mlly: 1.8.2
-      nypm: 0.6.5
+      mlly: 1.8.1
+      nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10107,14 +10124,14 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
       '@unhead/vue': 2.1.12(vue@3.5.31(typescript@6.0.2))
-      '@vue/shared': 3.5.31
+      '@vue/shared': 3.5.30
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       destr: 2.0.5
       devalue: 5.6.4
       errx: 0.1.0
@@ -10124,10 +10141,10 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.3.0
       lru-cache: 11.3.5
-      mlly: 1.8.2
+      mlly: 1.8.1
       mocked-exports: 0.1.1
-      nitro: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      nuxt: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      nitro: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      nuxt: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       ohash: 2.0.11
       pathe: 2.0.3
       rou3: 0.8.1
@@ -10182,8 +10199,8 @@ snapshots:
 
   '@nuxt/schema-nightly@5.0.0-29563820.579db312':
     dependencies:
-      '@vue/shared': 3.5.31
-      defu: 6.1.7
+      '@vue/shared': 3.5.30
+      defu: 6.1.4
       pathe: 2.0.3
       pkg-types: 2.3.0
       std-env: 4.0.0
@@ -10197,10 +10214,10 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@nuxt/test-utils@4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@clack/prompts': 1.0.0
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
@@ -10226,46 +10243,46 @@ snapshots:
       tinyexec: 1.0.4
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 1.0.1(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+      vitest-environment-nuxt: 1.0.1(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       vue: 3.5.31(typescript@6.0.2)
     optionalDependencies:
-      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - crossws
       - magicast
       - typescript
       - vite
 
-  '@nuxt/vite-builder-nightly@5.0.0-29563820.579db312(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@types/node@25.5.0)(esbuild@0.27.4)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder-nightly@5.0.0-29563820.579db312(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@types/node@25.5.0)(esbuild@0.27.4)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.6(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+      '@vitejs/plugin-vue': 6.0.6(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
       get-port-please: 3.2.0
       jiti: 2.6.1
       knitwork: 1.3.0
       magic-string: 0.30.21
-      mlly: 1.8.2
+      mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       pathe: 2.0.3
       pkg-types: 2.3.0
       seroval: 1.5.2
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-checker: 0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-checker: 0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vue: 3.5.31(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.0.0-rc.15
+      rolldown: 1.0.0-rc.17
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -10295,16 +10312,16 @@ snapshots:
     dependencies:
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.6(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+      '@vitejs/plugin-vue': 6.0.6(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
       get-port-please: 3.2.0
       jiti: 2.6.1
       knitwork: 1.3.0
       magic-string: 0.30.21
-      mlly: 1.8.2
+      mlly: 1.8.1
       mocked-exports: 0.1.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10312,9 +10329,9 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-checker: 0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-checker: 0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vue: 3.5.31(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -10345,11 +10362,11 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxtjs/tailwindcss@7.0.0-beta.1(magicast@0.5.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@nuxtjs/tailwindcss@7.0.0-beta.1(magicast@0.5.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@tailwindcss/postcss': 4.2.2
-      '@tailwindcss/vite': 4.2.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tailwindcss/vite': 4.2.2(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       exsolve: 1.0.8
       pathe: 2.0.3
       tailwindcss: 4.2.2
@@ -10644,9 +10661,9 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.123.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@oxc-parser/binding-wasm32-wasi@0.123.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -10678,7 +10695,7 @@ snapshots:
 
   '@oxc-project/types@0.123.0': {}
 
-  '@oxc-project/types@0.124.0': {}
+  '@oxc-project/types@0.127.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.120.0':
     optional: true
@@ -10889,7 +10906,7 @@ snapshots:
   '@parcel/watcher-wasm@2.5.6':
     dependencies:
       is-glob: 4.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.3
 
   '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
@@ -10905,7 +10922,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.3
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -11318,7 +11335,7 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
@@ -11327,7 +11344,7 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
@@ -11336,7 +11353,7 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
@@ -11345,7 +11362,7 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
@@ -11354,7 +11371,7 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
@@ -11363,7 +11380,7 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
@@ -11372,7 +11389,7 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
@@ -11381,7 +11398,7 @@ snapshots:
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
@@ -11390,7 +11407,7 @@ snapshots:
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
@@ -11399,7 +11416,7 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
@@ -11408,7 +11425,7 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
@@ -11417,7 +11434,7 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
@@ -11428,11 +11445,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
@@ -11443,7 +11460,7 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
@@ -11452,7 +11469,7 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
@@ -11464,7 +11481,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -11481,7 +11498,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.59.0
 
@@ -12119,19 +12136,19 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
+  '@tailwindcss/vite@4.2.2(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@tailwindcss/vite@4.2.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@tailwindcss/node': 4.2.2
-      '@tailwindcss/oxide': 4.2.2
-      tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@takumi-rs/core-darwin-arm64@0.73.1':
     optional: true
@@ -12662,10 +12679,10 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.31(typescript@6.0.2)
 
   '@vitest/expect@4.1.2':
@@ -12677,14 +12694,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@6.0.2)
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -13643,6 +13660,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -15366,7 +15385,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  misina@0.2.0: {}
+  misina@0.4.0(undici@7.24.4):
+    optionalDependencies:
+      undici: 7.24.4
 
   mitata@1.0.34: {}
 
@@ -15541,7 +15562,7 @@ snapshots:
 
   nf3@0.3.11: {}
 
-  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.13)
@@ -15562,7 +15583,7 @@ snapshots:
       giget: 3.2.0
       jiti: 2.6.1
       rollup: 4.59.0
-      vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15593,7 +15614,7 @@ snapshots:
       - sqlite3
       - uploadthing
 
-  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.13)
@@ -15614,7 +15635,7 @@ snapshots:
       giget: 3.2.0
       jiti: 2.6.1
       rollup: 4.59.0
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15693,16 +15714,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
-      '@nuxt/devtools': 3.2.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
-      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'
+      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'
       '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29563820.579db312'
       '@nuxt/telemetry': 2.7.0(@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2))
-      '@nuxt/vite-builder': '@nuxt/vite-builder-nightly@5.0.0-29563820.579db312(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@types/node@25.5.0)(esbuild@0.27.4)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(rolldown@1.0.0-rc.15)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(yaml@2.8.3)'
+      '@nuxt/vite-builder': '@nuxt/vite-builder-nightly@5.0.0-29563820.579db312(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@types/node@25.5.0)(esbuild@0.27.4)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(oxlint@1.57.0)(rolldown@1.0.0-rc.17)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(yaml@2.8.3)'
       '@unhead/vue': 2.1.12(vue@3.5.31(typescript@6.0.2))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -15827,13 +15848,13 @@ snapshots:
       - yaml
       - zephyr-agent
 
-  nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@parcel/watcher@2.5.6)(@pinia/colada@1.0.0(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2)))(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(db0@0.3.4)(dotenv@17.3.1)(esbuild@0.27.4)(giget@3.2.0)(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.57.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': '@nuxt/cli-nightly@3.35.0-20260421-182640-b9a9b49(@nuxt/schema-nightly@5.0.0-29563820.579db312)(magicast@0.5.2)'
-      '@nuxt/devtools': 3.2.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2)'
-      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'
+      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29563820.579db312(@babel/core@7.29.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.3.1)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(magicast@0.5.2)(nuxt-nightly@5.0.0-29563820.579db312)(ofetch@2.0.0-alpha.3)(rollup@4.59.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))'
       '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29563820.579db312'
       '@nuxt/telemetry': 2.7.0(@nuxt/kit-nightly@5.0.0-29563820.579db312(magicast@0.5.2))
       '@nuxt/vite-builder': '@nuxt/vite-builder-nightly@5.0.0-29563820.579db312(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.9)(@types/node@25.5.0)(esbuild@0.27.4)(magicast@0.5.2)(oxlint@1.57.0)(rolldown@1.0.0-rc.12)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(yaml@2.8.3)'
@@ -15966,6 +15987,12 @@ snapshots:
       citty: 0.2.1
       pathe: 2.0.3
       tinyexec: 1.0.4
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.1.1
 
   object-assign@4.1.1: {}
 
@@ -16130,7 +16157,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.120.0
       '@oxc-parser/binding-win32-x64-msvc': 0.120.0
 
-  oxc-parser@0.123.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  oxc-parser@0.123.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.123.0
     optionalDependencies:
@@ -16150,7 +16177,7 @@ snapshots:
       '@oxc-parser/binding-linux-x64-gnu': 0.123.0
       '@oxc-parser/binding-linux-x64-musl': 0.123.0
       '@oxc-parser/binding-openharmony-arm64': 0.123.0
-      '@oxc-parser/binding-wasm32-wasi': 0.123.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-parser/binding-wasm32-wasi': 0.123.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-parser/binding-win32-arm64-msvc': 0.123.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.123.0
       '@oxc-parser/binding-win32-x64-msvc': 0.123.0
@@ -16366,7 +16393,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -16826,26 +16853,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rolldown@1.0.0-rc.9:
     dependencies:
@@ -17400,6 +17427,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -17771,23 +17803,23 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-dev-rpc@1.1.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-hot-client@2.1.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-node@6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 7.0.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -17802,23 +17834,23 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-checker@0.12.0(@biomejs/biome@2.4.9)(oxlint@1.57.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.3
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vscode-uri: 3.1.0
     optionalDependencies:
       '@biomejs/biome': 2.4.9
       oxlint: 1.57.0
       typescript: 6.0.2
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -17828,8 +17860,8 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
@@ -17845,15 +17877,30 @@ snapshots:
       rollup: 4.59.0
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vite-plugin-vue-tracer@1.3.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2)):
+  vite-plugin-vue-tracer@1.3.0(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.31(typescript@6.0.2)
+
+  vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -17870,28 +17917,13 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.5.0
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vitefu@1.1.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest-environment-nuxt@1.0.1(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  vitest-environment-nuxt@1.0.1(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
-      '@nuxt/test-utils': 4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+      '@nuxt/test-utils': 4.0.0(crossws@0.4.5(srvx@0.11.13))(magicast@0.5.2)(typescript@6.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -17908,10 +17940,10 @@ snapshots:
       - vite
       - vitest
 
-  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -17928,7 +17960,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/src/client/adapters/misina/index.ts
+++ b/src/client/adapters/misina/index.ts
@@ -1,12 +1,54 @@
 /**
- * misina-based RPC transport — v2 client link.
+ * misina-based RPC transport — silgi client link.
  *
- * Uses misina for: retry (with Retry-After parsing), timeout, hook
- * lifecycle, redirect security, NetworkError vs HTTPError taxonomy,
- * idempotency keys for retried mutations.
+ * Thin shim over a misina instance. The adapter owns four things — and
+ * nothing else:
  *
- * Side-by-side alternative to the ofetch link. Same Silgi semantics,
- * different transport. Pick whichever fits your stack.
+ *   1. URL construction from the path tuple
+ *   2. Protocol negotiation (json / messagepack / devalue) — sets
+ *      content-type/accept and encodes the body accordingly
+ *   3. Per-call `responseType: 'stream'` override so SSE subscription
+ *      responses can be decoded lazily
+ *   4. SilgiError lifting from the response payload, plus mapping
+ *      misina's HTTPError / NetworkError / TimeoutError onto SilgiError
+ *
+ * Everything else — retry, timeout, hooks, idempotency, redirect policy,
+ * plugins (cache, breaker, dedupe, cookies, auth, otel, …) — lives on the
+ * misina instance you pass in. Configure misina once with
+ * `createMisina({ baseURL, retry, use: [plugin(), …] })` and hand the
+ * result here.
+ *
+ * @example
+ * ```ts
+ * import { createMisina } from "misina"
+ * import { cache } from "misina/cache"
+ * import { breaker } from "misina/breaker"
+ * import { bearer } from "misina/auth"
+ * import { createClient } from "silgi/client"
+ * import { createLink } from "silgi/client/misina"
+ *
+ * const url = "http://localhost:3000"
+ *
+ * const link = createLink({
+ *   url,
+ *   misina: createMisina({
+ *     baseURL: url,
+ *     retry: 3,
+ *     idempotencyKey: "auto",
+ *     use: [
+ *       bearer(() => store.token),
+ *       cache({ ttl: 60_000 }),
+ *       breaker({ failureThreshold: 5, windowMs: 30_000 }),
+ *     ],
+ *   }),
+ * })
+ *
+ * const client = createClient<AppRouter>(link)
+ * ```
+ *
+ * If `misina` is omitted, the adapter constructs a minimal default
+ * instance (`createMisina({ baseURL })`). That's fine for plain RPC; opt
+ * into retries, plugins, hooks, etc. by passing your own instance.
  */
 
 import { createMisina, isHTTPError, isNetworkError, isTimeoutError } from 'misina'
@@ -16,37 +58,28 @@ import { SilgiError, isSilgiErrorJSON, fromSilgiErrorJSON } from '../../../core/
 import { eventStreamToIterator } from '../../../core/sse.ts'
 
 import type { ClientLink, ClientContext, ClientOptions } from '../../types.ts'
-import type { AfterResponseHook, BeforeErrorHook, BeforeRequestHook, MisinaHooks, RetryOptions } from 'misina'
-
-type OnCompleteHook =
-  Exclude<MisinaHooks['onComplete'], undefined> extends infer H ? (H extends readonly (infer U)[] ? U : H) : never
+import type { Misina } from 'misina'
 
 export interface LinkOptions<TClientContext extends ClientContext = ClientContext> {
-  /** Server base URL (e.g. "http://localhost:3000") */
+  /** Server base URL (e.g. "http://localhost:3000"). */
   url: string
 
-  /** Static headers or dynamic header factory */
-  headers?: Record<string, string> | ((options: ClientOptions<TClientContext>) => Record<string, string>)
-
   /**
-   * Retry policy. Number sets the limit; pass a full `RetryOptions` to
-   * tune backoff, status codes, jitter. `false` disables retries.
+   * Misina instance the adapter dispatches through. Configure retry,
+   * timeout, hooks, plugins (`use: [...]`), idempotency keys, redirect
+   * policy, custom drivers, etc. on this instance — the adapter does not
+   * accept those options directly.
    *
-   * @default 0
+   * If omitted, the adapter calls `createMisina({ baseURL: url })`. Pass
+   * your own instance to opt into anything beyond default fetch behavior.
    */
-  retry?: number | boolean | RetryOptions
-
-  /** Per-attempt timeout in ms. `false` disables. (default: 30000) */
-  timeout?: number | false
-
-  /** Wall-clock deadline across all attempts (ms). `false` disables. */
-  totalTimeout?: number | false
+  misina?: Misina
 
   /**
    * Wire protocol for request/response encoding.
    *
    * - `'json'` — default, standard JSON
-   * - `'messagepack'` — 2-4x faster, ~50% smaller payloads
+   * - `'messagepack'` — 2–4× faster, ~50% smaller payloads
    * - `'devalue'` — preserves Date, Map, Set, BigInt, circular refs
    *
    * @default 'json'
@@ -54,68 +87,46 @@ export interface LinkOptions<TClientContext extends ClientContext = ClientContex
   protocol?: 'json' | 'messagepack' | 'devalue'
 
   /**
-   * Auto-generate `Idempotency-Key` for retried mutations. `'auto'` uses
-   * `crypto.randomUUID()` when retries are enabled. Pass a string to
-   * pin one, or a function for custom generation.
+   * Static headers or a per-call factory. Headers configured on the
+   * misina instance still apply; these are merged on top per call.
    */
-  idempotencyKey?: false | 'auto' | string | ((request: Request) => string)
-
-  /** misina hooks — direct pass-through */
-  beforeRequest?: BeforeRequestHook
-  afterResponse?: AfterResponseHook
-  beforeError?: BeforeErrorHook
-  onComplete?: OnCompleteHook
+  headers?:
+    | HeadersInit
+    | Record<string, string | undefined>
+    | ((options: ClientOptions<TClientContext>) =>
+        | HeadersInit
+        | Record<string, string | undefined>)
 }
 
 /**
  * Create a Silgi client link powered by misina.
  *
- * @example
- * ```ts
- * import { createClient } from "silgi/client"
- * import { createLink } from "silgi/client/misina"
- *
- * const link = createLink({ url: "http://localhost:3000" })
- * const client = createClient<AppRouter>(link)
- * const users = await client.users.list({ limit: 10 })
- * ```
+ * @see {@link LinkOptions} for the full shape and the misina-instance
+ * pattern.
  */
 export function createLink<TClientContext extends ClientContext = ClientContext>(
   options: LinkOptions<TClientContext>,
 ): ClientLink<TClientContext> {
   const baseUrl = options.url.endsWith('/') ? options.url.slice(0, -1) : options.url
-  const resolvedProtocol: 'json' | 'messagepack' | 'devalue' = options.protocol ?? 'json'
-
-  const misina = createMisina({
-    timeout: options.timeout ?? 30_000,
-    totalTimeout: options.totalTimeout,
-    retry: options.retry ?? 0,
-    idempotencyKey: options.idempotencyKey,
-    throwHttpErrors: false,
-    hooks: {
-      beforeRequest: options.beforeRequest,
-      afterResponse: options.afterResponse,
-      beforeError: options.beforeError,
-      onComplete: options.onComplete,
-    },
-  })
+  const protocol: 'json' | 'messagepack' | 'devalue' = options.protocol ?? 'json'
+  // Default instance — minimal, no retry, no plugins. Users opting into
+  // any transport-shaping behavior pass their own.
+  const misina = options.misina ?? createMisina({ baseURL: baseUrl })
 
   return {
     async call(path, input, callOptions) {
+      // Always send a fully-qualified URL. The user's misina instance
+      // may or may not have baseURL set; the adapter doesn't depend on it.
       const url = `${baseUrl}/${path.map(encodeURIComponent).join('/')}`
 
-      // Resolve headers
-      const headers: Record<string, string> = {
-        ...(typeof options.headers === 'function' ? options.headers(callOptions) : options.headers),
-      }
+      const headers = resolveHeaders(options.headers, callOptions)
 
-      // Protocol selection: messagepack > devalue > json (default)
       let body: unknown
-      if (resolvedProtocol === 'messagepack') {
+      if (protocol === 'messagepack') {
         headers['content-type'] = MSGPACK_CONTENT_TYPE
         headers['accept'] = MSGPACK_CONTENT_TYPE
         body = input !== undefined && input !== null ? msgpackEncode(input) : undefined
-      } else if (resolvedProtocol === 'devalue') {
+      } else if (protocol === 'devalue') {
         const { encode: devalueEncode, DEVALUE_CONTENT_TYPE } = await import('../../../codec/devalue.ts')
         headers['content-type'] = DEVALUE_CONTENT_TYPE
         headers['accept'] = DEVALUE_CONTENT_TYPE
@@ -125,30 +136,32 @@ export function createLink<TClientContext extends ClientContext = ClientContext>
       }
 
       try {
-        // `responseType: 'stream'` keeps misina from consuming the body
-        // so we can branch on `content-type`: subscriptions need the
-        // raw stream for SSE decoding, while query/mutation responses
-        // get decoded here per protocol.
+        // Per-call overrides win over instance defaults — the adapter must
+        // own `responseType: 'stream'` (so SSE subscriptions can be decoded
+        // lazily and protocol-encoded responses can be drained on our
+        // schedule) and `throwHttpErrors: false` (we lift HTTPError into
+        // SilgiError ourselves and never want misina to swallow the body).
         const result = await misina.post(url, body, {
           headers,
           signal: callOptions.signal,
           responseType: 'stream',
+          throwHttpErrors: false,
         })
 
         const response = result.raw
 
-        // Subscription response — server emitted an async iterator as SSE.
+        // Subscription — server emitted an async iterator as SSE.
         const responseContentType = response.headers.get('content-type') ?? ''
         if (responseContentType.includes('text/event-stream') && response.body) {
           return eventStreamToIterator(response.body)
         }
 
-        // Query/mutation — drain the stream and decode per protocol.
+        // Query/mutation — drain and decode per protocol.
         let decoded: unknown
-        if (resolvedProtocol === 'messagepack') {
+        if (protocol === 'messagepack') {
           const buf = new Uint8Array(await response.arrayBuffer())
           decoded = buf.length > 0 ? msgpackDecode(buf) : undefined
-        } else if (resolvedProtocol === 'devalue') {
+        } else if (protocol === 'devalue') {
           const text = await response.text()
           if (text) {
             const { decode: devalueDecode } = await import('../../../codec/devalue.ts')
@@ -175,10 +188,8 @@ export function createLink<TClientContext extends ClientContext = ClientContext>
 
         return decoded
       } catch (error) {
-        // Re-throw SilgiError as-is
         if (error instanceof SilgiError) throw error
 
-        // misina HTTPError carries server payload — try to lift SilgiError shape
         if (isHTTPError(error)) {
           const data = (error as any).data
           if (isSilgiErrorJSON(data)) {
@@ -203,3 +214,37 @@ export function createLink<TClientContext extends ClientContext = ClientContext>
     },
   }
 }
+
+function resolveHeaders<TClientContext extends ClientContext>(
+  headers: LinkOptions<TClientContext>['headers'],
+  callOptions: ClientOptions<TClientContext>,
+): Record<string, string> {
+  const raw = typeof headers === 'function' ? headers(callOptions) : headers
+  const out: Record<string, string> = {}
+  if (raw == null) return out
+
+  if (raw instanceof Headers) {
+    raw.forEach((value, key) => {
+      out[key] = value
+    })
+    return out
+  }
+
+  if (Array.isArray(raw)) {
+    for (const [k, v] of raw) {
+      if (v == null) continue
+      out[k] = String(v)
+    }
+    return out
+  }
+
+  for (const [k, v] of Object.entries(raw as Record<string, string | undefined>)) {
+    if (v == null) continue
+    out[k] = String(v)
+  }
+  return out
+}
+
+// Re-export the `Misina` type so callers can write `LinkOptions['misina']`
+// or annotate variables without a separate `import from 'misina'`.
+export type { Misina } from 'misina'

--- a/src/client/adapters/misina/index.ts
+++ b/src/client/adapters/misina/index.ts
@@ -93,9 +93,7 @@ export interface LinkOptions<TClientContext extends ClientContext = ClientContex
   headers?:
     | HeadersInit
     | Record<string, string | undefined>
-    | ((options: ClientOptions<TClientContext>) =>
-        | HeadersInit
-        | Record<string, string | undefined>)
+    | ((options: ClientOptions<TClientContext>) => HeadersInit | Record<string, string | undefined>)
 }
 
 /**

--- a/test/client/misina.test.ts
+++ b/test/client/misina.test.ts
@@ -1,11 +1,16 @@
 /**
  * misina client link — integration tests.
  *
- * Spins up a real silgi server and tests the misina-based client.
+ * Adapter-only concerns: URL construction, protocol negotiation, header
+ * resolution, SSE branching, AbortSignal forwarding, SilgiError lift,
+ * misina-instance pass-through. Anything misina owns (retry, timeout,
+ * idempotencyKey, validateResponse, plugins, hooks) is covered by
+ * misina's own test suite — we just verify our pass-through is wired.
  */
 
 import { createServer } from 'node:http'
 
+import { createMisina } from 'misina'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { z } from 'zod'
 
@@ -106,6 +111,8 @@ afterAll(() => {
 // ── Tests ───────────────────────────────────────────
 
 describe('misina client link', () => {
+  // Default instance — adapter constructs its own misina when none given.
+
   it('creates a typed client and calls a no-input query', async () => {
     const link = createLink({ url: baseUrl })
     const client = createClient<InferClient<AppRouter>>(link)
@@ -155,7 +162,20 @@ describe('misina client link', () => {
     await expect((client as any).nonexistent()).rejects.toThrow()
   })
 
-  it('supports custom headers', async () => {
+  it('forwards AbortSignal to misina', async () => {
+    const link = createLink({ url: baseUrl })
+    const client = createClient<InferClient<AppRouter>>(link)
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(client.health(undefined, { signal: controller.signal })).rejects.toThrow()
+  })
+
+  // Headers — adapter-specific feature (per-call factory + Headers/Record/array
+  // shapes), so we test it here instead of relying on misina's own header tests.
+
+  it('supports headers as Record', async () => {
     const link = createLink({
       url: baseUrl,
       headers: { 'x-custom': 'test-value' },
@@ -166,84 +186,88 @@ describe('misina client link', () => {
     expect(result.status).toBe('ok')
   })
 
-  it('supports dynamic headers', async () => {
-    let headersCalled = false
+  it('supports headers as Headers instance', async () => {
+    const link = createLink({
+      url: baseUrl,
+      headers: new Headers({ 'x-custom': 'header-instance' }),
+    })
+    const client = createClient<InferClient<AppRouter>>(link)
+    const result = await client.health()
+    expect(result.status).toBe('ok')
+  })
+
+  it('supports headers as a per-call factory', async () => {
+    let factoryCalls = 0
     const link = createLink({
       url: baseUrl,
       headers: () => {
-        headersCalled = true
+        factoryCalls += 1
         return { authorization: 'Bearer test' }
       },
     })
     const client = createClient<InferClient<AppRouter>>(link)
 
     await client.health()
-    expect(headersCalled).toBe(true)
+    await client.health()
+    expect(factoryCalls).toBe(2)
   })
 
-  it('supports timeout', async () => {
+  it('drops undefined header values silently', async () => {
     const link = createLink({
       url: baseUrl,
-      timeout: 5000,
+      headers: { authorization: undefined, 'x-real': 'present' },
     })
     const client = createClient<InferClient<AppRouter>>(link)
-
     const result = await client.health()
     expect(result.status).toBe('ok')
   })
 
-  it('supports AbortSignal', async () => {
-    const link = createLink({ url: baseUrl })
-    const client = createClient<InferClient<AppRouter>>(link)
+  // Instance pass-through — the canonical extension surface.
 
-    const controller = new AbortController()
-    controller.abort()
-
-    await expect(client.health(undefined, { signal: controller.signal })).rejects.toThrow()
-  })
-
-  it('supports beforeRequest hook', async () => {
-    let intercepted = false
-    const link = createLink({
-      url: baseUrl,
-      beforeRequest: () => {
-        intercepted = true
+  it('uses a user-provided misina instance', async () => {
+    let dispatched = 0
+    const m = createMisina({
+      hooks: {
+        beforeRequest: () => {
+          dispatched += 1
+        },
       },
     })
+    const link = createLink({ url: baseUrl, misina: m })
     const client = createClient<InferClient<AppRouter>>(link)
 
-    await client.health()
-    expect(intercepted).toBe(true)
+    const result = await client.health()
+    expect(result.status).toBe('ok')
+    expect(dispatched).toBe(1)
   })
 
-  it('supports afterResponse hook', async () => {
-    let responseStatus = 0
-    const link = createLink({
-      url: baseUrl,
-      afterResponse: ({ response }) => {
-        if (response) responseStatus = response.status
-      },
-    })
-    const client = createClient<InferClient<AppRouter>>(link)
-
-    await client.health()
-    expect(responseStatus).toBe(200)
-  })
-
-  it('supports onComplete terminal hook', async () => {
+  it('flows misina instance hooks (onComplete) end-to-end', async () => {
     let completed = false
     let durationMs = -1
-    const link = createLink({
-      url: baseUrl,
-      onComplete: (info) => {
-        completed = true
-        durationMs = info.durationMs
+    const m = createMisina({
+      hooks: {
+        onComplete: (info) => {
+          completed = true
+          durationMs = info.durationMs
+        },
       },
     })
+    const link = createLink({ url: baseUrl, misina: m })
     const client = createClient<InferClient<AppRouter>>(link)
 
     await client.health()
     expect(completed).toBe(true)
     expect(durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('overrides instance throwHttpErrors so SilgiError still surfaces from 5xx', async () => {
+    // User instance has throwHttpErrors: true (the misina default). The adapter
+    // must override it per-call to false so we can lift SilgiError ourselves.
+    const m = createMisina({ throwHttpErrors: true })
+    const link = createLink({ url: baseUrl, misina: m })
+    const client = createClient<InferClient<AppRouter>>(link as any)
+
+    // 404 path — adapter should turn the misina HTTPError into a SilgiError.
+    await expect((client as any).nonexistent()).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

Refactor the misina client link to take a `Misina` instance only — no more re-exposing `retry` / `timeout` / `hooks` / `idempotencyKey` / `validateResponse` / `redirect*` / etc. on the link surface. This is the pattern misina recommends for adapter authors (see [productdevbook/misina#108](https://github.com/productdevbook/misina/issues/108)).

**This is a breaking change** intended for silgi v0.54.

> Supersedes #31, which shipped the full hybrid surface. Closing that in favor of this minimal version.

## Migration

```ts
// before (v0.53)
createLink({
  url,
  retry: 3,
  timeout: 5000,
  idempotencyKey: 'auto',
  beforeRetry: refreshToken,
})

// after (v0.54)
import { createMisina } from 'misina'

createLink({
  url,
  misina: createMisina({
    retry: 3,
    timeout: 5000,
    idempotencyKey: 'auto',
    hooks: { beforeRetry: refreshToken },
  }),
})
```

For plugin composition — the case where the old API couldn't help at all — it's now first-class:

```ts
import { createMisina } from 'misina'
import { cache } from 'misina/cache'
import { breaker } from 'misina/breaker'
import { bearer, refreshOn401 } from 'misina/auth'

createLink({
  url,
  misina: createMisina({
    baseURL: url,
    retry: 3,
    use: [
      bearer(() => store.token),
      refreshOn401({ refresh: getNewToken }),
      cache({ ttl: 60_000 }),
      breaker({ failureThreshold: 5, windowMs: 30_000 }),
    ],
  }),
})
```

## Why

The hybrid surface had three costs the adapter couldn't mitigate:

1. **Drift on every misina release** — `bodyTimeout` / `maxResponseSize` / `decompress` / `compressRequestBody` / `requestIdHeaders` / `redirectStripHeaders` all had to be added manually as 0.3.x rolled out.
2. **Plugins are unreachable from flat options** — since misina 0.4.0, plugins (cache, breaker, dedupe, cookies, auth, otel, tracing, …) live on `createMisina({ use: [...] })`. A flat-options adapter could at best paraphrase that field, never expose plugin composition naturally.
3. **Two ways to do the same thing** forced duplicated documentation and ambiguous defaults.

Per [misina#108](https://github.com/productdevbook/misina/issues/108), the recommended adapter pattern going forward is instance-only.

## What the adapter still owns

These are silgi-specific concerns — never delegated to misina:

- URL construction from path tuples (`path.map(encodeURIComponent).join('/')`)
- Protocol negotiation (json / messagepack / devalue) — sets content-type + accept and encodes the body
- Per-call \`responseType: 'stream'\` override so SSE subscriptions decode lazily and protocol-encoded bodies drain on our schedule
- Per-call \`throwHttpErrors: false\` so \`SilgiError\` can be lifted from the payload regardless of the user's instance default
- \`SilgiError\` lift + misina \`HTTPError\` / \`NetworkError\` / \`TimeoutError\` mapping

## Stats

- Adapter src: ~250 → ~110 LOC of actual code (rest is JSDoc with the migration example)
- Generated \`.d.mts\`: ~150 → 41 lines
- Tests: 26 → 14 focused on adapter-only concerns (URL / protocol / header resolution / SSE branching / AbortSignal forwarding / SilgiError lift / instance pass-through). Cases that duplicated misina's own test coverage (timeout, retry, idempotency, validateResponse, etc.) removed — misina's suite owns those.
- misina: ^0.2.0 → ^0.4.0

## Test plan

- [x] \`pnpm test test/client/misina.test.ts\` — 14/14 pass
- [x] \`pnpm test\` — 940/959 pass (skips unchanged)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — dist generated, exports verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)